### PR TITLE
Move DictDataset from test utils to API

### DIFF
--- a/tfep/io/dataset/__init__.py
+++ b/tfep/io/dataset/__init__.py
@@ -1,2 +1,3 @@
 from tfep.io.dataset.traj import TrajectoryDataset, TrajectorySubset, get_subsampled_indices
 from tfep.io.dataset.merged import MergedDataset
+from tfep.io.dataset.dict import DictDataset

--- a/tfep/io/dataset/dict.py
+++ b/tfep/io/dataset/dict.py
@@ -21,7 +21,7 @@ import torch.utils.data
 
 
 # =============================================================================
-# MERGED DATASET
+# DICTIONARY DATASET
 # =============================================================================
 
 class DictDataset(torch.utils.data.Dataset):
@@ -46,7 +46,7 @@ class DictDataset(torch.utils.data.Dataset):
             A dictionary of named tensors.
 
         """
-        self.tensor_dict = tensor_dict
+        self._tensor_dict = tensor_dict
 
     def __getitem__(self, item):
         """Retrieve a dataset sample.
@@ -61,9 +61,9 @@ class DictDataset(torch.utils.data.Dataset):
         samples : dict[str, torch.Tensor]
             A dictionary of named tensor.
         """
-        return {k: v[item] for k, v in self.tensor_dict.items()}
+        return {k: v[item] for k, v in self._tensor_dict.items()}
 
     def __len__(self):
         """The number of samples in the dataset."""
-        for vals in self.tensor_dict.values():
+        for vals in self._tensor_dict.values():
             return len(vals)

--- a/tfep/io/dataset/dict.py
+++ b/tfep/io/dataset/dict.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Utility class to create a map-style PyTorch ``Dataset``s from a dictionary of tensors.
+
+For usage examples see the documentation of :class:`.DictDataset`.
+
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import torch
+
+
+# =============================================================================
+# MERGED DATASET
+# =============================================================================
+
+class DictDataset(torch.utils.data.Dataset):
+    """Utility class to create a map-style PyTorch ``Dataset``s from a dictionary of tensors."""
+
+    def __init__(self, tensor_dict : dict[str, torch.Tensor]):
+        """Constructor.
+
+        Parameters
+        ----------
+        tensor_dict : dict[str, torch.Tensor]
+            A dictionary of named tensors.
+
+        """
+        self.tensor_dict = tensor_dict
+
+    def __getitem__(self, item):
+        """Retrive a dataset sample.
+
+        Parameters
+        ----------
+        item : int or slice
+            The index (or slice) of the sample(s).
+
+        Returns
+        -------
+        samples : dict[str, torch.Tensor]
+            A dictionary of named tensor.
+        """
+        return {k: v[item] for k, v in self.tensor_dict.items()}
+
+    def __len__(self):
+        """The number of samples in the dataset."""
+        for vals in self.tensor_dict.values():
+            return len(vals)

--- a/tfep/io/dataset/dict.py
+++ b/tfep/io/dataset/dict.py
@@ -5,8 +5,8 @@
 # MODULE DOCSTRING
 # =============================================================================
 
-"""
-Utility class to create a map-style PyTorch ``Dataset``s from a dictionary of tensors.
+r"""
+Utility class to create a map-style PyTorch ``Dataset``\ s from a dictionary of tensors.
 
 For usage examples see the documentation of :class:`.DictDataset`.
 
@@ -17,7 +17,7 @@ For usage examples see the documentation of :class:`.DictDataset`.
 # GLOBAL IMPORTS
 # =============================================================================
 
-import torch
+import torch.utils.data
 
 
 # =============================================================================
@@ -25,7 +25,17 @@ import torch
 # =============================================================================
 
 class DictDataset(torch.utils.data.Dataset):
-    """Utility class to create a map-style PyTorch ``Dataset``s from a dictionary of tensors."""
+    r"""Utility class to create a map-style PyTorch ``Dataset``\ s from a dictionary of tensors.
+
+    Examples
+    --------
+    >>> import torch
+    >>> data = {'a': torch.tensor([1.0, 2.0]), 'b': torch.tensor([3, 4])}
+    >>> dict_dataset = DictDataset(data)
+    >>> dict_dataset[1]
+    {'a': tensor(2.), 'b': tensor(4)}
+
+    """
 
     def __init__(self, tensor_dict : dict[str, torch.Tensor]):
         """Constructor.
@@ -39,7 +49,7 @@ class DictDataset(torch.utils.data.Dataset):
         self.tensor_dict = tensor_dict
 
     def __getitem__(self, item):
-        """Retrive a dataset sample.
+        """Retrieve a dataset sample.
 
         Parameters
         ----------

--- a/tfep/io/dataset/merged.py
+++ b/tfep/io/dataset/merged.py
@@ -6,7 +6,7 @@
 # =============================================================================
 
 """
-Utility class to merge multiple PyTorch ``Dataset``s.
+Utility class to merge multiple PyTorch ``Dataset``\ s.
 
 For usage examples see the documentation of :class:`.MergedDataset`.
 
@@ -25,7 +25,7 @@ import torch.utils.data
 # =============================================================================
 
 class MergedDataset(torch.utils.data.Dataset):
-    """Dataset merging multiple ``Dataset``s.
+    """Dataset merging multiple ``Dataset``\ s.
 
     The dataset constructs a batch by merging batches from the wrapped datasets.
     Currently, it supports only map-style datasets that return samples in

--- a/tfep/io/dataset/merged.py
+++ b/tfep/io/dataset/merged.py
@@ -5,7 +5,7 @@
 # MODULE DOCSTRING
 # =============================================================================
 
-"""
+r"""
 Utility class to merge multiple PyTorch ``Dataset``\ s.
 
 For usage examples see the documentation of :class:`.MergedDataset`.
@@ -25,20 +25,33 @@ import torch.utils.data
 # =============================================================================
 
 class MergedDataset(torch.utils.data.Dataset):
-    """Dataset merging multiple ``Dataset``\ s.
+    r"""Dataset merging multiple ``Dataset``\ s.
 
     The dataset constructs a batch by merging batches from the wrapped datasets.
     Currently, it supports only map-style datasets that return samples in
     dictionary format.
 
-    Parameters
-    ----------
-    *datasets : torch.utils.data.Dataset
-        The map-style datasets to be merged. These must all have the same number
-        of samples and return samples in dictionary format.
+    Examples
+    --------
+    >>> import torch
+    >>> from tfep.io.dataset import DictDataset
+    >>> dataset1 = DictDataset({'a': torch.tensor([1., 2.])})
+    >>> dataset2 = DictDataset({'b': torch.tensor([3, 4])})
+    >>> merged = MergedDataset(dataset1, dataset2)
+    >>> merged[1]
+    {'a': tensor(2.), 'b': tensor(4)}
 
     """
     def __init__(self, *datasets):
+        """Constructor.
+
+        Parameters
+        ----------
+        *datasets : torch.utils.data.Dataset
+            The map-style datasets to be merged. These must all have the same
+            number of samples and return samples in dictionary format.
+
+        """
         super().__init__()
 
         # Check that the datasets all have the same number of samples.

--- a/tfep/io/dataset/merged.py
+++ b/tfep/io/dataset/merged.py
@@ -33,10 +33,9 @@ class MergedDataset(torch.utils.data.Dataset):
 
     Examples
     --------
-    >>> import torch
     >>> from tfep.io.dataset import DictDataset
-    >>> dataset1 = DictDataset({'a': torch.tensor([1., 2.])})
-    >>> dataset2 = DictDataset({'b': torch.tensor([3, 4])})
+    >>> dataset1 = DictDataset({'a': [1., 2.]})
+    >>> dataset2 = DictDataset({'b': [3, 4]})
     >>> merged = MergedDataset(dataset1, dataset2)
     >>> merged[1]
     {'a': tensor(2.), 'b': tensor(4)}

--- a/tfep/tests/io/test_dataset_dict.py
+++ b/tfep/tests/io/test_dataset_dict.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test objects and function in the module ``tfep.io.dataset.dict``.
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import numpy as np
+import pytest
+import torch
+
+from tfep.io.dataset.dict import DictDataset
+
+
+# =============================================================================
+# TEST DICTDATASET
+# =============================================================================
+
+def test_conversion():
+    """Lists/arrays etc. are converted to tensors."""
+    d = DictDataset({
+        'a': [0, 1],
+        'b': np.array([2, 3]),
+        'c': torch.tensor([4, 5])
+    })
+    sample = d[0]
+    samples = d[:]
+
+    for s in [sample, samples]:
+        for val in s.values():
+            assert isinstance(val, torch.Tensor)
+
+
+def test_raise_different_length():
+    """An error is raised if the dictionary's elements have different lengths."""
+    with pytest.raises(ValueError, match='must all have the same length'):
+        DictDataset({'a': [0, 1], 'b': [2]})

--- a/tfep/tests/io/test_dataset_merged.py
+++ b/tfep/tests/io/test_dataset_merged.py
@@ -18,24 +18,8 @@ import pytest
 import torch
 import torch.utils.data
 
+from tfep.io.dataset.dict import DictDataset
 from tfep.io.dataset.merged import MergedDataset
-
-
-# =============================================================================
-# TEST UTILITY FUNCTIONS
-# =============================================================================
-
-class DictDataset(torch.utils.data.Dataset):
-    """Dataset to merge for the tests below."""
-    def __init__(self, tensor_dict):
-        self.tensor_dict = tensor_dict
-
-    def __getitem__(self, item):
-        return {k: v[item] for k, v in self.tensor_dict.items()}
-
-    def __len__(self):
-        for vals in self.tensor_dict.values():
-            return len(vals)
 
 
 # =============================================================================


### PR DESCRIPTION
This exposes the ``DictDataset`` utility class which was used only internally in the tests.