### PR TITLE
StatefulBatchSampler for data loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ pytorch >= 1.11
 mdanalysis >= 2.0
 pint
 numpy
+lightning >= 2.0
 ```
 and the following optional dependencies
 ```
@@ -52,7 +53,7 @@ example that creates a separate conda environment with all the dependencies and 
 
 ```bash
 # Required dependencies.
-conda create --name tfepenv pytorch">=1.11" mdanalysis">=2.0" pint numpy -c conda-forge
+conda create --name tfepenv pytorch">=1.11" mdanalysis">=2.0" pint numpy lightning">=2.0" -c conda-forge
 conda activate tfepenv
 
 # Optional dependency using pip.

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -20,6 +20,7 @@ dependencies:
   - mdanalysis >=2.0
   - numpy
   - pint
+  - lightning >=2.0
 
     # Optional packages.
   - psi4

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,6 +9,7 @@ The library has the following required dependencies
     mdanalysis >= 2.0
     pint
     numpy
+    lightning >= 2.0
 
 and the following optional dependencies
 
@@ -25,7 +26,7 @@ example that creates a separate conda environment with all the dependencies and 
 .. code-block:: bash
 
     # Required dependencies.
-    conda create --name tfepenv pytorch">=1.11" mdanalysis">=2.0" pint numpy -c conda-forge
+    conda create --name tfepenv pytorch">=1.11" mdanalysis">=2.0" pint numpy lightning">=2.0" -c conda-forge
     conda activate tfepenv
 
     # Optional dependency using pip.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "mdanalysis>=2.0",
     "numpy",
     "pint",
+    "lightning>=2.0",
 ]
 
 # Update the urls once the hosting is set up.

--- a/tfep/io/__init__.py
+++ b/tfep/io/__init__.py
@@ -1,2 +1,6 @@
 from tfep.io.cache import TFEPCache
-from tfep.io.dataset import TrajectoryDataset, TrajectorySubset, get_subsampled_indices
+from tfep.io.dataset import (
+    DictDataset, MergedDataset, TrajectoryDataset,
+    TrajectorySubset, get_subsampled_indices,
+)
+from tfep.io.sampler import StatefulBatchSampler

--- a/tfep/io/cache.py
+++ b/tfep/io/cache.py
@@ -28,7 +28,7 @@ import torch
 
 
 # =============================================================================
-# TRAJECTORY DATASET
+# TFEP CACHE
 # =============================================================================
 
 class TFEPCache:
@@ -39,7 +39,7 @@ class TFEPCache:
 
     .. warning::
 
-        Currently, this class does is not multi-process or thread safe.
+        Currently, this class is not multi-process or thread safe.
 
     Current database format
     -----------------------
@@ -65,21 +65,6 @@ class TFEPCache:
     Finally, a JSON file is used to store metadata about the experiment such as
     batch and epoch sizes.
 
-    Parameters
-    ----------
-    save_dir_path : str, optional
-        The main directory where to save the training and evaluation data. If not
-        given, it defaults to the current working directory.
-    data_loader : torch.utils.data.DataLoader, optional
-        The data loader used for training wrapping a :class:``tfep.io.dataset.TrajectoryDataset``.
-        This must be passed when a new cache is created as it is used to determine
-        epoch, batch, and trajectory dimensions. If ``save_dir_path`` points to
-        an existing cache, then this is ignored.
-    train_subdir_name : str, optional
-        The name of the subdirectory where the training data is stored.
-    eval_subdir_name : str, optional
-        The name of the subdirectory where the evaluation data is stored.
-
     """
 
     VERSION = '0.1'
@@ -94,6 +79,24 @@ class TFEPCache:
             train_subdir_name='train',
             eval_subdir_name='eval',
     ):
+        """Constructor.
+
+        Parameters
+        ----------
+        save_dir_path : str, optional
+            The main directory where to save the training and evaluation data.
+            If not given, it defaults to the current working directory.
+        data_loader : torch.utils.data.DataLoader, optional
+            The data loader used for training wrapping a :class:``tfep.io.dataset.TrajectoryDataset``.
+            This must be passed when a new cache is created as it is used to
+            determine epoch, batch, and trajectory dimensions. If ``save_dir_path``
+            points to an existing cache, then this is ignored.
+        train_subdir_name : str, optional
+            The name of the subdirectory where the training data is stored.
+        eval_subdir_name : str, optional
+            The name of the subdirectory where the evaluation data is stored.
+
+        """
         self._save_dir_path = os.path.realpath(save_dir_path)
         self._train_dir_path = os.path.join(save_dir_path, train_subdir_name)
         self._eval_dir_path = os.path.join(save_dir_path, eval_subdir_name)

--- a/tfep/io/sampler.py
+++ b/tfep/io/sampler.py
@@ -150,7 +150,7 @@ class StatefulBatchSampler(torch.utils.data.Sampler):
             generator.manual_seed(self._current_epoch_seed)
             epoch_indices = torch.randperm(len(self._dataset), generator=generator)
         else:  # Sequential.
-            epoch_indices = torch.range(0, len(self._dataset)-1, dtype=int)
+            epoch_indices = torch.arange(0, len(self._dataset), dtype=int)
 
         # Yield indices.
         for batch_idx in range(current_batch_idx, len(self)):

--- a/tfep/io/sampler.py
+++ b/tfep/io/sampler.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+A PyTorch stateful batch sampler that can be used to correctly resume training mid-epoch.
+
+See documentation of the class :class:`StatefulBatchSampler` for more details.
+
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from typing import Any, Iterator, Optional
+
+import torch
+
+
+# =============================================================================
+# STATEFUL BATCH SAMPLER
+# =============================================================================
+
+class StatefulBatchSampler:
+    """A PyTorch stateful batch sampler to resume training mid-epoch.
+
+    This class can be used with a PyTorch Lightning ``Trainer`` to implement
+    a correct data checkpointing. If the training is interrupted mid-epoch, and
+    the ``DataLoader`` uses this batch sampler, the training will resume correctly,
+    i.e., it will complete the epoch by training only on the data points that
+    were not previously seen.
+
+    Examples
+    --------
+    >>> import torch
+    >>> import lightning
+    >>> import tfep.io
+    >>>
+    >>> # Initialize the trainer. This must be passed to StatefulBatchSampler.
+    >>> trainer = lightning.Trainer()
+    >>>
+    >>> # Initialize the dataset and data loader.
+    >>> dataset = tfep.io.DictDataset({'a': [0, 1, 2, 3, 4]})
+    >>> sampler = StatefulBatchSampler(
+    ...     dataset,
+    ...     batch_size=2,
+    ...     shuffle=True,
+    ...     drop_last=True,
+    ...     trainer=trainer
+    ... )
+    >>> dataloader = torch.utils.data.DataLoader(dataset, batch_sampler=sampler)
+    >>>
+    >>> # Train your model.
+    >>> trainer.fit(your_model, dataloader)  # doctest: +SKIP
+
+    """
+
+    def __init__(
+            self,
+            dataset : torch.utils.data.Dataset,
+            batch_size : int = 1,
+            shuffle : bool = False,
+            drop_last : bool = False,
+            trainer = None
+    ):
+        """Constructor.
+
+        Parameters
+        ----------
+        dataset : torch.utils.data.Dataset
+            The dataset to sample.
+        batch_size : int, optional
+            The batch size.
+        shuffle : bool, optional
+            If ``True``, data samples are reshuffled at every epoch.
+        drop_last : bool, optional
+            If the dataset size is not divisible by the batch size the last batch
+            is dropped if this is ``True`` or just smaller if this is ``False``.
+        trainer : object or None, optional
+            An object exposing a ``global_step`` attribute that holds the total
+            number of seen batches during the entire training. This is usually a
+            PyTorch Lightning ``Trainer`` object. If not given on initialization,
+            this must be passed later through the :attr:`~StatefulBatchSampler.trainer`
+            attribute.
+
+        """
+        self._dataset = dataset
+        self._batch_size = batch_size
+        self._shuffle = shuffle
+        self._drop_last = drop_last
+
+        # Keeps track of the seed used to shuffle the data in the current epoch.
+        self._current_epoch_seed = None
+
+        #: The trainer object exposing a ``global_step`` attribute with the total number of batches seen during the entire training.
+        self.trainer : Optional[Any] = trainer
+
+    @property
+    def batch_size(self) -> int:
+        """The batch size."""
+        return self._batch_size
+
+    @property
+    def shuffle(self) -> bool:
+        """Whether to reshuffle the data at each new epoch."""
+        return self._shuffle
+
+    @property
+    def drop_last(self) -> bool:
+        """Whether the last incomplete batch is dropped or yielded."""
+        return self._drop_last
+
+    def __len__(self) -> int:
+        """The number of batches per epoch."""
+        if self.drop_last:
+            return len(self._dataset) // self.batch_size
+        return (len(self._dataset) + self.batch_size - 1) // self.batch_size
+
+    def __iter__(self) -> Iterator[torch.Tensor]:
+        """Iterate over batches.
+
+        Yields
+        ------
+        batch_indices : torch.Tensor[int]
+            A tensor of sample indices forming the batch.
+
+        """
+        if self.trainer is None:
+            raise RuntimeError('trainer must be set before starting the training.')
+
+        # This is usually called at the start of each epoch but current_batch_idx
+        # might be != 0 if this is resumed from a mid-epoch checkpoint.
+        current_batch_idx = self.trainer.global_step % len(self)
+
+        # Get the random indices.
+        if self.shuffle:
+            # If this is a new epoch, regenerate the seed.
+            if current_batch_idx == 0:
+                self._current_epoch_seed = int(torch.empty((), dtype=torch.int64).random_().item())
+
+            # Create a random permutation of the sample indices.
+            generator = torch.Generator()
+            generator.manual_seed(self._current_epoch_seed)
+            epoch_indices = torch.randperm(len(self._dataset), generator=generator)
+        else:  # Sequential.
+            epoch_indices = torch.range(0, len(self._dataset)-1, dtype=int)
+
+        # Yield indices.
+        for batch_idx in range(current_batch_idx, len(self)):
+            start = batch_idx * self.batch_size
+            end = (batch_idx + 1) * self.batch_size
+            yield epoch_indices[start:end]
+
+    def state_dict(self) -> dict[str, Any]:
+        """Serialize the internal state in dictionary format.
+
+        Note that the parameters passed in the constructor are not serialized.
+
+        Returns
+        -------
+        state_dict : dict[str, Any]
+            The serialized internal state.
+
+        """
+        return {'current_epoch_seed': self._current_epoch_seed}
+
+    def load_state_dict(self, state_dict: dict[str, Any]):
+        """Load the internal state from a dictionary.
+
+        The dictionary must be generated with :func:`~StatefulBatchSampler.state_dict`.
+        Note that the parameters passed in the constructor are not serialized,
+        and thus the object must be initialized with the same arguments to recover
+        the same object.
+
+        Parameters
+        ----------
+        state_dict : dict[str, Any]
+            The serialized internal state.
+
+        """
+        self._current_epoch_seed = state_dict['current_epoch_seed']

--- a/tfep/io/sampler.py
+++ b/tfep/io/sampler.py
@@ -26,7 +26,7 @@ import torch
 # STATEFUL BATCH SAMPLER
 # =============================================================================
 
-class StatefulBatchSampler:
+class StatefulBatchSampler(torch.utils.data.Sampler):
     """A PyTorch stateful batch sampler to resume training mid-epoch.
 
     This class can be used with a PyTorch Lightning ``Trainer`` to implement
@@ -89,6 +89,8 @@ class StatefulBatchSampler:
             attribute.
 
         """
+        super().__init__()
+
         self._dataset = dataset
         self._batch_size = batch_size
         self._shuffle = shuffle

--- a/tfep/tests/io/test_sampler.py
+++ b/tfep/tests/io/test_sampler.py
@@ -56,7 +56,7 @@ def test_shuffle(dataset_len5, shuffle):
 
     # Check the data order.
     x = next(iter(dataloader))['x']
-    sequential = torch.range(0, len(dataset_len5)-1, dtype=int)
+    sequential = torch.arange(0, len(dataset_len5), dtype=int)
     if shuffle:
         assert not torch.equal(x, sequential)
     else:

--- a/tfep/tests/io/test_sampler.py
+++ b/tfep/tests/io/test_sampler.py
@@ -109,3 +109,13 @@ def test_resuming(dataset_len5):
     # In the second run, the first batch is not returned.
     assert len(samples2) == len(samples1) - 2
     assert samples2 == samples1[2:]
+
+
+def test_trainer_set(dataset_len5):
+    """An error is raised if the training is started without setting the trainer."""
+    trainer = MockTrainer()
+    sampler = StatefulBatchSampler(dataset_len5, shuffle=True, batch_size=2, drop_last=False)
+    dataloader = torch.utils.data.DataLoader(dataset_len5, batch_sampler=sampler)
+
+    with pytest.raises(RuntimeError, match='trainer must be set'):
+        next(iter(dataloader))

--- a/tfep/tests/io/test_sampler.py
+++ b/tfep/tests/io/test_sampler.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test objects and function in the module ``tfep.io.sampler``.
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import pytest
+import torch
+
+from tfep.io.dataset import DictDataset
+from tfep.io.sampler import StatefulBatchSampler
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+@pytest.fixture
+def dataset_len5():
+    return DictDataset({
+        'x': list(range(5)),
+        'y': list(range(5, 10)),
+    })
+
+
+# =============================================================================
+# TEST UTILITIES
+# =============================================================================
+
+class MockTrainer:
+    """A mock trainer holding the global step."""
+    def __init__(self):
+        self.global_step = 0
+
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+@pytest.mark.parametrize('shuffle', [False, True])
+def test_shuffle(dataset_len5, shuffle):
+    """The shuffle argument controls the data order."""
+    trainer = MockTrainer()
+    sampler = StatefulBatchSampler(dataset_len5, batch_size=len(dataset_len5), shuffle=shuffle, trainer=trainer)
+    dataloader = torch.utils.data.DataLoader(dataset_len5, batch_sampler=sampler)
+
+    # Check the data order.
+    x = next(iter(dataloader))['x']
+    sequential = torch.range(0, len(dataset_len5)-1, dtype=int)
+    if shuffle:
+        assert not torch.equal(x, sequential)
+    else:
+        assert torch.equal(x, sequential)
+
+
+@pytest.mark.parametrize('drop_last', [False, True])
+def test_drop_last(dataset_len5, drop_last):
+    """The drop_last argument works as expected."""
+    trainer = MockTrainer()
+    sampler = StatefulBatchSampler(dataset_len5, batch_size=2, drop_last=drop_last, trainer=trainer)
+    dataloader = torch.utils.data.DataLoader(dataset_len5, batch_sampler=sampler)
+
+    # Count the number of batches.
+    for batch in dataloader:
+        trainer.global_step += 1
+
+    # Test drop last.
+    if drop_last:
+        assert len(sampler) == 2
+    else:
+        assert len(sampler) == 3
+    assert trainer.global_step == len(sampler)
+
+
+def test_resuming(dataset_len5):
+    """A new StatefulBatchSampler can correctly recover the data order given its internal state."""
+    trainer = MockTrainer()
+    sampler = StatefulBatchSampler(dataset_len5, shuffle=True, batch_size=2, drop_last=False, trainer=trainer)
+    dataloader = torch.utils.data.DataLoader(dataset_len5, batch_sampler=sampler)
+
+    # Get the samples order and save the state after the first step.
+    samples1 = []
+    for batch_idx, batch in enumerate(dataloader):
+        if batch_idx == 0:
+            sampler_state = sampler.state_dict()
+        samples1.extend(batch['x'].detach().tolist())
+
+    # Now simulate resuming after the first batch with a new sampler and dataloader.
+    sampler = StatefulBatchSampler(dataset_len5, shuffle=True, batch_size=2, drop_last=False, trainer=trainer)
+    dataloader = torch.utils.data.DataLoader(dataset_len5, batch_sampler=sampler)
+
+    sampler.load_state_dict(sampler_state)
+    trainer.global_step = 1
+
+    samples2 = []
+    for batch in dataloader:
+        samples2.extend(batch['x'].detach().tolist())
+
+    # In the second run, the first batch is not returned.
+    assert len(samples2) == len(samples1) - 2
+    assert samples2 == samples1[2:]


### PR DESCRIPTION
This PR implements the ``StatefulBatchSampler`` utility class which can be used to resume the training mid-epoch without revisiting data points that were previously seen. This is meant to be used with PyTorch Lightning, which I've added to the dependencies.