### PR TITLE
Add atom indices map from GROMACS to CPMD for MiMiC

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The library also includes several utilities:
 
 The library has the following required dependencies
 ```
+python >= 3.9
 pytorch >= 1.11
 mdanalysis >= 2.0
 pint
@@ -55,7 +56,7 @@ example that creates a separate conda environment with all the dependencies and 
 
 ```bash
 # Required dependencies.
-conda create --name tfepenv pytorch">=1.11" mdanalysis">=2.0" pint numpy lightning">=2.0" -c conda-forge
+conda create --name tfepenv python">=3.9" pytorch">=1.11" mdanalysis">=2.0" pint numpy lightning">=2.0" -c conda-forge
 conda activate tfepenv
 
 # Optional dependency using conda.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,6 +5,7 @@ The library has the following required dependencies
 
 .. code-block::
 
+    python >= 3.9
     pytorch >= 1.11
     mdanalysis >= 2.0
     pint
@@ -28,7 +29,7 @@ example that creates a separate conda environment with all the dependencies and 
 .. code-block:: bash
 
     # Required dependencies.
-    conda create --name tfepenv pytorch">=1.11" mdanalysis">=2.0" pint numpy lightning">=2.0" -c conda-forge
+    conda create --name tfepenv python">=3.9" pytorch">=1.11" mdanalysis">=2.0" pint numpy lightning">=2.0" -c conda-forge
     conda activate tfepenv
 
     # Optional dependency using conda.

--- a/tfep/potentials/mimic.py
+++ b/tfep/potentials/mimic.py
@@ -42,7 +42,7 @@ from tfep.potentials.base import PotentialBase
 from tfep.utils.cli import Launcher, CLITool, KeyValueOption
 from tfep.utils.misc import (
     flattened_to_atom, energies_array_to_tensor, forces_array_to_tensor, temporary_cd)
-from tfep.utils.parallel import SerialStrategy
+from tfep.utils.parallel import ParallelizationStrategy, SerialStrategy
 
 
 # =============================================================================
@@ -223,7 +223,7 @@ class PotentialMiMiC(PotentialBase):
             precompute_gradient: bool = True,
             working_dir_path: Optional[Union[str, List[str]]]=None,
             cleanup_working_dir: bool = False,
-            parallelization_strategy: Optional[tfep.utils.parallel.ParallelizationStrategy] = None,
+            parallelization_strategy: Optional[ParallelizationStrategy] = None,
             launcher_kwargs: Optional[Dict[str, Any]] = None,
             grompp_launcher_kwargs: Optional[Dict[str, Any]] = None,
             n_attempts: int = 1,
@@ -681,7 +681,7 @@ class PotentialEnergyMiMiCFunc(torch.autograd.Function):
             precompute_gradient: bool = True,
             working_dir_path: Optional[Union[str, List[str]]]=None,
             cleanup_working_dir: bool = False,
-            parallelization_strategy: Optional[tfep.utils.parallel.ParallelizationStrategy] = None,
+            parallelization_strategy: Optional[ParallelizationStrategy] = None,
             launcher_kwargs: Optional[Dict[str, Any]] = None,
             grompp_launcher_kwargs: Optional[Dict[str, Any]] = None,
             n_attempts: int = 1,
@@ -791,7 +791,7 @@ def potential_energy_mimic(
         precompute_gradient: bool = True,
         working_dir_path: Optional[Union[str, List[str]]]=None,
         cleanup_working_dir: bool = False,
-        parallelization_strategy: Optional[tfep.utils.parallel.ParallelizationStrategy] = None,
+        parallelization_strategy: Optional[ParallelizationStrategy] = None,
         launcher_kwargs: Optional[Dict[str, Any]] = None,
         grompp_launcher_kwargs: Optional[Dict[str, Any]] = None,
         n_attempts: int = 1,
@@ -852,7 +852,7 @@ def _run_mimic(
         unit_registry: pint.UnitRegistry = None,
         working_dir_path: Optional[Union[str, List[str]]]=None,
         cleanup_working_dir: bool = False,
-        parallelization_strategy: Optional[tfep.utils.parallel.ParallelizationStrategy] = None,
+        parallelization_strategy: Optional[ParallelizationStrategy] = None,
         launcher_kwargs: Optional[Dict[str, Any]] = None,
         grompp_launcher_kwargs: Optional[Dict[str, Any]] = None,
         n_attempts: int = 1,


### PR DESCRIPTION
- Added a mandatory argument ``gromacs_to_cpmd_atom_indices`` to ``PotentialMiMiC`` to solve the problem of CPMD scrambling the original atom order from GROMACS. The map can be computed using MiMiCPy with ``mimicpy.CpmdScript.gmx_to_cpmd_idx``. In the future, we'll evaluate if making this map optional and have ``PotentialMiMiC`` using MiMiCPy inside the constructor.
- Added a class variable ``SRunLauncher.GLOBAL_SRUN_OPTIONS`` which allows centralizing the options to pass to all ``srun`` commands.
- Added minimum python version on installation instructions.
- Minor fixes to docstrings and annotations.