### PR TITLE
Fix bug when axes atoms where partially mapped

### DIFF
--- a/tfep/nn/flows/oriented.py
+++ b/tfep/nn/flows/oriented.py
@@ -21,7 +21,9 @@ import torch
 from tfep.nn.flows.partial import PartialFlow
 from tfep.utils.geometry import (
     vector_vector_angle, vector_plane_angle,
-    rotation_matrix_3d, batchwise_rotate)
+    rotation_matrix_3d, batchwise_rotate,
+    reference_frame_rotation_matrix,
+)
 from tfep.utils.math import batchwise_dot
 from tfep.utils.misc import (
     flattened_to_atom, atom_to_flattened, atom_to_flattened_indices)
@@ -181,54 +183,21 @@ class OrientedFlow(PartialFlow):
 
     def _transform(self, x, inverse=False):
         """Apply the forward/inverse transformation."""
-        batch_size = x.shape[0]
-
         # Reshape coordinates to be in standard atom format.
         x = flattened_to_atom(x)
 
-        # Find the direction perpendicular to the plane formed by the axis atom,
-        # and the axis. torch.cross() requires tensors of same size but at least
-        # torch.expand() does not allocate new memory.
-        axis = self._axis.expand((batch_size, 3))
+        # Find the rotation matrices.
+        rotation_matrices = reference_frame_rotation_matrix(
+            axis_atom_positions=x[:, self._axis_point_idx],
+            plane_atom_positions=x[:, self._plane_point_idx],
+            axis=self._axis,
+            plane_axis=self._plane_axis,
+            plane_normal=self._plane_normal,
+            # We need this to be invertible if the axis atom is flipped.
+            project_on_positive_axis=False,
+        )
 
-        # rotation_vectors has shape (batch_size, 3).
-        rotation_vectors = torch.cross(x[:, self._axis_point_idx], axis, dim=1)
-
-        # Find the first rotation angle. r1_angle has shape (batch_size,).
-        r1_angles = vector_vector_angle(
-            x[:, self._axis_point_idx], self._axis)
-
-        # r1_angles goes from 0 to pi. We want to rotate the point onto the
-        # negative/positive axis, depending which is closest.
-        r1_angles = r1_angles - torch.pi * (r1_angles > torch.pi/2).to(r1_angles.dtype)
-
-        # This are the rotation matrices that bring the axis points onto the axis.
-        r1_rotation_matrices = rotation_matrix_3d(r1_angles, rotation_vectors)
-
-        # To bring the plane atom in position, we perform a rotation about
-        # self._axis so that we don't modify the position of the axis atom.
-        # We perform the first rotation only on the atom position that will
-        # determine the next rotation matrix for now so that we run only
-        # a single matmul on all atoms.
-        plane_points = x[:, self._plane_point_idx].unsqueeze(1)
-        plane_points = batchwise_rotate(plane_points, r1_rotation_matrices)
-        plane_points = plane_points.squeeze(1)
-
-        # Project the atom on the plane perpendicular to the rotation axis plane
-        # to measure the rotation angle.
-        plane_points = plane_points - self._axis*batchwise_dot(plane_points, self._axis, keepdim=True)
-        r2_angles = vector_plane_angle(plane_points, self._plane_normal)
-
-        # r2_angles will be positive in the octants where self._plane_normal
-        # lies and negative in the opposite direction but the rotation happens
-        # counterclockwise/clockwise with positive/negative angle so we need
-        # to fix the sign of the angle based on where it is.
-        r2_angles_sign = -torch.sign(batchwise_dot(plane_points, self._plane_axis))
-        r2_rotation_matrices = rotation_matrix_3d(
-            r2_angles_sign * r2_angles, self._axis)
-
-        # Now build the rotation composition before applying the transformation.
-        rotation_matrices = torch.bmm(r2_rotation_matrices, r1_rotation_matrices)
+        # Rotate frame of reference.
         x = batchwise_rotate(x, rotation_matrices)
 
         # Re-shape back to flattened format.

--- a/tfep/nn/flows/oriented.py
+++ b/tfep/nn/flows/oriented.py
@@ -20,13 +20,15 @@ import torch
 
 from tfep.nn.flows.partial import PartialFlow
 from tfep.utils.geometry import (
-    vector_vector_angle, vector_plane_angle,
-    rotation_matrix_3d, batchwise_rotate,
+    batchwise_rotate,
+    get_axis_from_name,
     reference_frame_rotation_matrix,
 )
-from tfep.utils.math import batchwise_dot
 from tfep.utils.misc import (
-    flattened_to_atom, atom_to_flattened, atom_to_flattened_indices)
+    flattened_to_atom,
+    atom_to_flattened,
+    atom_to_flattened_indices,
+)
 
 
 # =============================================================================
@@ -55,13 +57,6 @@ class OrientedFlow(PartialFlow):
     z coordinates (in this order) of the ``i``-th point for batch sample ``b``.
 
     """
-
-    # Conversion string representation to vector representation.
-    _AXES = {
-        'x': torch.tensor([1.0, 0.0, 0.0]),
-        'y': torch.tensor([0.0, 1.0, 0.0]),
-        'z': torch.tensor([0.0, 0.0, 1.0]),
-    }
 
     def __init__(
             self,
@@ -133,11 +128,11 @@ class OrientedFlow(PartialFlow):
                              "'axis_atom_idx' must be constrained on an axis on the same plane.")
 
         # Save the axis used for contraining the first point as a vector.
-        self._axis = self._AXES[axis].type(torch.get_default_dtype())
+        self._axis = get_axis_from_name(axis)
 
         # Save the axis that together with self._axis defines the plane on which
         # the second point is contrained.
-        self._plane_axis = [x.type(self._axis.dtype) for name, x in self._AXES.items()
+        self._plane_axis = [get_axis_from_name(name) for name in ['x', 'y', 'z']
                             if (name not in axis) and (name in plane)][0]
 
         # Save the plane used for constraining the second point as its normal vector.

--- a/tfep/tests/app/__init__.py
+++ b/tfep/tests/app/__init__.py
@@ -124,7 +124,7 @@ def check_atom_groups(
     # The flow doesn't alter but still depends on the conditioning DOFs.
     if expected_conditioning is not None:
         assert torch.allclose(x[:, expected_conditioning], y[:, expected_conditioning])
-        assert torch.all(~torch.isclose(x_grad[:, expected_conditioning], torch.ones(*x[:, expected_conditioning].shape)))
+        assert torch.all(~torch.isclose(x_grad[:, expected_conditioning], torch.ones(*x[:, expected_conditioning].shape), rtol=0.0))
 
     # The flow doesn't alter and doesn't depend on the fixed DOFs.
     if expected_fixed is not None:

--- a/tfep/tests/nn/flows/test_oriented.py
+++ b/tfep/tests/nn/flows/test_oriented.py
@@ -19,6 +19,7 @@ import torch
 
 import tfep.nn.flows
 from tfep.nn.flows.oriented import OrientedFlow
+from tfep.utils.geometry import get_axis_from_name
 from tfep.utils.math import batchwise_dot
 from tfep.utils.misc import atom_to_flattened, flattened_to_atom
 
@@ -132,9 +133,8 @@ def test_oriented_flow(flow, axis_point_idx, plane_point_idx, axis, plane, rotat
         expected_directions = torch.nn.functional.normalize(x[:, axis_point_idx])
         expected_normal_planes = torch.nn.functional.normalize(torch.cross(expected_directions, x[:, plane_point_idx]))
     else:
-        expected_directions = OrientedFlow._AXES[axis].type(x.dtype)
-        expected_normal_planes = [OrientedFlow._AXES[a].type(x.dtype)
-                                  for a in ['x', 'y', 'z'] if a not in plane][0]
+        expected_directions = get_axis_from_name(axis)
+        expected_normal_planes = [get_axis_from_name(a) for a in ['x', 'y', 'z'] if a not in plane][0]
 
     # The axis atom is on the expected axis.
     normalized_y_axis = torch.nn.functional.normalize(y[:, axis_point_idx])

--- a/tfep/tests/potentials/test_mimic.py
+++ b/tfep/tests/potentials/test_mimic.py
@@ -228,7 +228,7 @@ def test_prepare_cpmd_command(update_positions):
         tmp_dir_path = os.path.realpath(tmp_dir_path)
 
         # Run the tested function
-        new_cpmd_cmd, _ = _prepare_cpmd_command(cpmd_cmd, tmp_dir_path, new_positions, new_box_vectors)
+        new_cpmd_cmd = _prepare_cpmd_command(cpmd_cmd, tmp_dir_path, new_positions, new_box_vectors)
 
         # Test that the commands were updated.
         assert new_cpmd_cmd != cpmd_cmd
@@ -275,7 +275,7 @@ def test_prepare_cpmd_command(update_positions):
 
         # Now, if we re-prepare the new command without asking for updated
         # positions, it should not change it.
-        new_new_cpmd_cmd, _ = _prepare_cpmd_command(new_cpmd_cmd, tmp_dir_path)
+        new_new_cpmd_cmd = _prepare_cpmd_command(new_cpmd_cmd, tmp_dir_path)
         assert new_new_cpmd_cmd == new_cpmd_cmd
 
 

--- a/tfep/utils/geometry.py
+++ b/tfep/utils/geometry.py
@@ -346,7 +346,7 @@ def reference_frame_rotation_matrix(
     >>> # Fix the orientation of the coordiante frames based on the 2nd and 4th atoms.
     >>> axis_atom_pos = coordinates[:, 1]
     >>> plane_atom_pos = coordinates[:, 3]
-    >>> rotation_matrices = get_reference_frame_rotation_matrix(
+    >>> rotation_matrices = reference_frame_rotation_matrix(
     ...     axis_atom_pos,
     ...     plane_atom_pos,
     ...     axis=torch.tensor([1.0, 0, 0]),  # axis atom lies on x-axis

--- a/tfep/utils/geometry.py
+++ b/tfep/utils/geometry.py
@@ -14,7 +14,7 @@ Math and geometry utility functions to manipulate coordinates.
 # GLOBAL IMPORTS
 # =============================================================================
 
-from typing import Optional
+from typing import Dict, List, Literal, Optional, Tuple
 
 import torch
 
@@ -262,6 +262,37 @@ def batchwise_rotate(x, rotation_matrices, inverse=False):
         return torch.bmm(x, rotation_matrices.permute(0, 2, 1))
 
 
+# =============================================================================
+# COORDINATE TRANSFORMATIONS
+# =============================================================================
+
+# Map the name of an axis to its 3D unit vector representation. We instantiate
+# the tensor in get_axis_from_name to make sure it is represented by the default
+# floating type, which might not be set on import.
+_AXIS_NAME_TO_VECTOR: Dict[Literal['x', 'y', 'z'], List] = {
+    'x': [1.0, 0.0, 0.0],
+    'y': [0.0, 1.0, 0.0],
+    'z': [0.0, 0.0, 1.0],
+}
+
+
+def get_axis_from_name(name: Literal['x', 'y', 'z']) -> torch.Tensor:
+    """Return the 3D vector representation of an axis.
+
+    Parameters
+    ----------
+    name : Literal['x', 'y', 'z']
+        The name of the axis.
+
+    Returns
+    -------
+    axis : torch.Tensor
+        Shape ``(3,)``. The unit vector representation of the axis.
+
+    """
+    return torch.tensor(_AXIS_NAME_TO_VECTOR[name])
+
+
 def reference_frame_rotation_matrix(
         axis_atom_positions: torch.Tensor,
         plane_atom_positions: torch.Tensor,
@@ -297,8 +328,8 @@ def reference_frame_rotation_matrix(
         ``axis``. Otherwise, it is rotated on the positive or negative ``axis`` based
         on whichever is closest.
 
-        Note that if this is ``True`` and the position of the axis atom is flipped,
-        the returned rotation matrix cannot recover the original coordinates.
+        Note that if this is ``True``, a transformation that flips the sign of
+        the coordinate of the axis atom might become impossible to invert in practice.
 
     Returns
     -------

--- a/tfep/utils/geometry.py
+++ b/tfep/utils/geometry.py
@@ -404,3 +404,63 @@ def reference_frame_rotation_matrix(
     rotation_matrices = torch.bmm(r2_rotation_matrices, r1_rotation_matrices)
 
     return rotation_matrices
+
+
+def cartesian_to_polar(x: torch.Tensor, y: torch.Tensor, return_log_det_J: bool = False) -> Tuple[torch.Tensor]:
+    """Transform Cartesian coordinates into polar.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Shape ``(batch_size,)``. The x Cartesian coordinate.
+    y : torch.Tensor
+        Shape ``(batch_size,)``. The y Cartesian coordinate.
+    return_log_det_J: bool, optional
+        If ``True``, the absolute value of the Jacobian determinant of the
+        transformation is also returned.
+
+    Returns
+    -------
+    r : torch.Tensor
+        Shape ``(batch_size,)``. The radius coordinate.
+    angle : torch.Tensor
+        Shape ``(batch_size,)``. The angle coordinate in radians.
+    log_det_J : torch.Tensor, optional
+        The absolute value of the Jacobian determinant of the transformation.
+
+    """
+    r = (x.pow(2) + y.pow(2)).sqrt()
+    angle = torch.atan2(y, x)
+    if return_log_det_J:
+        return r, angle, -torch.log(r)
+    return r, angle
+
+
+def polar_to_cartesian(r: torch.Tensor, angle: torch.Tensor, return_log_det_J: bool = False) -> Tuple[torch.Tensor]:
+    """Transform polar coordinates into Cartesian.
+
+    Parameters
+    ----------
+    r : torch.Tensor
+        Shape ``(batch_size,)``. The radius coordinate.
+    angle : torch.Tensor
+        Shape ``(batch_size,)``. The angle coordinate in radians.
+    return_log_det_J: bool, optional
+        If ``True``, the absolute value of the Jacobian determinant of the
+        transformation is also returned.
+
+    Returns
+    -------
+    x : torch.Tensor
+        Shape ``(batch_size,)``. The x Cartesian coordinate.
+    y : torch.Tensor
+        Shape ``(batch_size,)``. The y Cartesian coordinate.
+    log_det_J : torch.Tensor, optional
+        The absolute value of the Jacobian determinant of the transformation.
+
+    """
+    x = r * torch.cos(angle)
+    y = r * torch.sin(angle)
+    if return_log_det_J:
+        return x, y, torch.log(r)
+    return x, y


### PR DESCRIPTION
Because the 2nd axes atom was represented with a distance relative to the 1st axes atom, the 2nd atom could change its position even if it was conditioning when the 1st axes atom was mapped.

This is solved here by expressing the position of the 2nd axes atom relative to the origin atom, which is always conditioning. This is also more consistent with the heuristics used to automatically construct the Z-matrix since the molecule's graph is searched breadth-first.