### PR TITLE
Neural spline transformer improvements

### DIFF
--- a/tfep/nn/transformers/affine.py
+++ b/tfep/nn/transformers/affine.py
@@ -42,7 +42,7 @@ class AffineTransformer(MAFTransformer):
 
     """
     # Number of parameters needed by the transformer for each input dimension.
-    n_parameters_per_input = 2
+    n_parameters_per_feature = 2
 
     def forward(self, x: torch.Tensor, parameters: torch.Tensor) -> tuple[torch.Tensor]:
         """Apply the affine transformation to the input.
@@ -112,7 +112,7 @@ class AffineTransformer(MAFTransformer):
             Shape ``(2*n_features)``. The parameters for the identity.
 
         """
-        return torch.zeros(size=(self.n_parameters_per_input*n_features,))
+        return torch.zeros(size=(self.n_parameters_per_feature*n_features,))
 
     def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
         """Returns the degrees associated to the conditioner's output.
@@ -131,13 +131,13 @@ class AffineTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_input,))
+        return degrees_in.tile((self.n_parameters_per_feature,))
 
     def _split_parameters(self, parameters):
         """Divide shift from log scale."""
         # From (batch, 2*n_features) to (batch, 2, n_features).
         batch_size = parameters.shape[0]
-        parameters = parameters.reshape(batch_size, self.n_parameters_per_input, -1)
+        parameters = parameters.reshape(batch_size, self.n_parameters_per_feature, -1)
         return parameters[:, 0], parameters[:, 1]
 
 
@@ -162,7 +162,7 @@ class VolumePreservingShiftTransformer(MAFTransformer):
 
     """
     # Number of parameters needed by the transformer for each input dimension.
-    n_parameters_per_input = 1
+    n_parameters_per_feature = 1
 
     def __init__(
             self,
@@ -252,7 +252,7 @@ class VolumePreservingShiftTransformer(MAFTransformer):
             Shape ``(n_features)``. The parameters for the identity.
 
         """
-        return torch.zeros(size=(self.n_parameters_per_input*n_features,))
+        return torch.zeros(size=(self.n_parameters_per_feature*n_features,))
 
     def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
         """Returns the degrees associated to the conditioner's output.
@@ -271,7 +271,7 @@ class VolumePreservingShiftTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_input,))
+        return degrees_in.tile((self.n_parameters_per_feature,))
 
 
 # =============================================================================

--- a/tfep/nn/transformers/moebius.py
+++ b/tfep/nn/transformers/moebius.py
@@ -54,7 +54,7 @@ class MoebiusTransformer(MAFTransformer):
 
     """
     # Number of parameters needed by the transformer for each input dimension.
-    n_parameters_per_input = 1
+    n_parameters_per_feature = 1
 
     def __init__(self, dimension: int, max_radius: float = 0.99, unit_sphere: bool = False):
         """Constructor.
@@ -170,7 +170,7 @@ class MoebiusTransformer(MAFTransformer):
             vector to perform the identity function with a Moebius transformer.
 
         """
-        return torch.zeros(size=(self.n_parameters_per_input*n_features,))
+        return torch.zeros(size=(self.n_parameters_per_feature*n_features,))
 
     def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
         """Returns the degrees associated to the conditioner's output.
@@ -189,7 +189,7 @@ class MoebiusTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_input,))
+        return degrees_in.tile((self.n_parameters_per_feature,))
 
 
 class SymmetrizedMoebiusTransformer(MAFTransformer):
@@ -220,7 +220,7 @@ class SymmetrizedMoebiusTransformer(MAFTransformer):
 
     """
     # Number of parameters needed by the transformer for each input dimension.
-    n_parameters_per_input = 1
+    n_parameters_per_feature = 1
 
     def __init__(self, dimension: int, max_radius: float = 0.99):
         """Constructor.
@@ -330,7 +330,7 @@ class SymmetrizedMoebiusTransformer(MAFTransformer):
             vector to perform the identity function with a Moebius transformer.
 
         """
-        return torch.zeros(size=(self.n_parameters_per_input*n_features,))
+        return torch.zeros(size=(self.n_parameters_per_feature*n_features,))
 
     def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
         """Returns the degrees associated to the conditioner's output.
@@ -349,7 +349,7 @@ class SymmetrizedMoebiusTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_input,))
+        return degrees_in.tile((self.n_parameters_per_feature,))
 
 
 # =============================================================================

--- a/tfep/nn/transformers/sos.py
+++ b/tfep/nn/transformers/sos.py
@@ -77,7 +77,7 @@ class SOSPolynomialTransformer(MAFTransformer):
         return self.degree_polynomials + 1
 
     @property
-    def n_parameters_per_input(self):
+    def n_parameters_per_feature(self):
         """Number of parameters needed by the transformer for each input dimension."""
         return self.parameters_per_polynomial * self.n_polynomials + 1
 
@@ -105,7 +105,7 @@ class SOSPolynomialTransformer(MAFTransformer):
         """
         # From (batch, n_parameters*n_features) to (batch, n_parameters, n_features).
         batch_size = parameters.shape[0]
-        parameters = parameters.reshape(batch_size, self.n_parameters_per_input, -1)
+        parameters = parameters.reshape(batch_size, self.n_parameters_per_feature, -1)
         return sos_polynomial_transformer(x, parameters)
 
     def inverse(self, y: torch.Tensor, parameters: torch.Tensor) -> tuple[torch.Tensor]:
@@ -131,7 +131,7 @@ class SOSPolynomialTransformer(MAFTransformer):
             and degree of the polynomials.
 
         """
-        id_conditioner = torch.zeros(size=(self.n_parameters_per_input, n_features))
+        id_conditioner = torch.zeros(size=(self.n_parameters_per_feature, n_features))
         # The sum of the squared linear parameters must be 1.
         id_conditioner[1::self.parameters_per_polynomial].fill_(np.sqrt(1 / self.n_polynomials))
         return id_conditioner.flatten()
@@ -153,7 +153,7 @@ class SOSPolynomialTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_input,))
+        return degrees_in.tile((self.n_parameters_per_feature,))
 
 
 # =============================================================================

--- a/tfep/nn/transformers/spline.py
+++ b/tfep/nn/transformers/spline.py
@@ -129,14 +129,16 @@ class NeuralSplineTransformer(MAFTransformer):
         x : torch.Tensor
             Shape ``(batch_size, n_features)``. Input features.
         parameters : torch.Tensor
-            Shape: ``(batch_size, 3*n_bins+1*n_features)``. Parameters of the
-            transformation, where ``parameters[b, i+j*n_features]`` with ``0<=j<n_bins``
-            determine the ``j``-th width, ``n_bins<=j<2*n_bins`` the ``j``-th height,
-            and ``2*n_bins<=j<3*n_bins`` the ``j``-th slop of the bins for feature
-            ``x[b, i]``. For ``j = 3*n_bins`` instead depend on whether the i-th
-            feature is periodic. If not periodic, they are interpreted the slopes
-            of the last knot. Otherwise, the slope of the last knot is set equal
-            to the first and the parameters are used as shifts.
+            Shape: ``(batch_size, (3*n_bins+1)*n_features)``. The order of the
+            parameters should allow reshaping the array to
+            ``(batch_size, 3*n_bins+1, n_features)``, where
+            ``parameters[b, :n_bins, i]``, ``parameters[b, n_bins:2*n_bins, i]``,
+            and ``parameters[b, 2*n_bins:3*n_bins, i]`` are the widths, heights,
+            and slopes for feature ``x[b, i]``. ``parameters[b, 3*n_bins, i]``
+            instead depends on whether the ``x[b, i]`` is periodic. If not
+            periodic, they are interpreted the slopes of the last knot. Otherwise,
+            the slope of the last knot is set equal to the first and the
+            parameters are used as shifts.
 
             As in the original paper, the passed widths and heights go through
             a ``softmax`` function and the slopes through a ``softplus`` function
@@ -187,13 +189,13 @@ class NeuralSplineTransformer(MAFTransformer):
     def get_identity_parameters(self, n_features: int) -> torch.Tensor:
         """Return the value of the parameters that makes this the identity function.
 
-        Note that if ``x0 != y0`` or ``y0 != y1`` it is
-        impossible to implement the identity using this transformer, and the
-        returned parameters will be those to map linearly the input domain of
-        ``x`` to the output of ``y``.
+        Note that if ``x0 != y0`` or ``y0 != y1`` it is impossible to implement
+        the identity using this transformer, and the returned parameters will
+        be those to map linearly the input domain of ``x`` to the output of
+        ``y``.
 
-        This can be used to initialize the normalizing flow to perform the identity
-        transformation.
+        This can be used to initialize the normalizing flow to perform the
+        identity transformation.
 
         Parameters
         ----------
@@ -203,8 +205,8 @@ class NeuralSplineTransformer(MAFTransformer):
         Returns
         -------
         parameters : torch.Tensor
-            A tensor of shape ``(K*n_features)``  where ``K`` equals ``3*n_bins``
-            if circular or ``3*n_bins+1`` if not.
+            Shape ``((3*n_bins+1)*n_features,)``. The parameters for the
+            identity function.
 
         """
         if not (torch.allclose(self.x0, self._y0) and torch.allclose(self.xf, self._yf)):

--- a/tfep/nn/transformers/spline.py
+++ b/tfep/nn/transformers/spline.py
@@ -137,7 +137,7 @@ class NeuralSplineTransformer(MAFTransformer):
         self.register_buffer('_min_slope', torch.as_tensor(min_slope))
 
     @property
-    def n_parameters_per_input(self) -> int:
+    def n_parameters_per_feature(self) -> int:
         """int: Number of parameters needed by the transformer for each feature."""
         if self._identity_boundary_slopes:
             if self._circular:
@@ -247,7 +247,7 @@ class NeuralSplineTransformer(MAFTransformer):
         # The slopes parameters in _get_parameters are offset so that the final
         # slope will be 1 when zeros are passed. This also sets the shifts to 0
         # for periodic features.
-        id_conditioner = torch.zeros(size=(self.n_parameters_per_input, n_features)).to(self.x0)
+        id_conditioner = torch.zeros(size=(self.n_parameters_per_feature, n_features)).to(self.x0)
 
         # Both the width and the height of each bin must be constant.
         # Remember that the parameters go through the softmax function.
@@ -273,7 +273,7 @@ class NeuralSplineTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_input,))
+        return degrees_in.tile((self.n_parameters_per_feature,))
 
     def _get_parameters(self, parameters: torch.Tensor) -> tuple[torch.Tensor]:
         """Return the parameters for the functional API.
@@ -304,7 +304,7 @@ class NeuralSplineTransformer(MAFTransformer):
         """
         # From (batch_size, n_par_per_feat*n_features) to (batch_size, n_par_per_feat, n_features).
         batch_size = parameters.shape[0]
-        parameters = parameters.reshape(batch_size, self.n_parameters_per_input, -1)
+        parameters = parameters.reshape(batch_size, self.n_parameters_per_feature, -1)
 
         # Extract parameters.
         widths = parameters[:, :self.n_bins]

--- a/tfep/nn/transformers/spline.py
+++ b/tfep/nn/transformers/spline.py
@@ -169,7 +169,13 @@ class NeuralSplineTransformer(MAFTransformer):
         # of the neural spline transformation. Shifting is volume preserving
         # (i.e., log_det_J = 0).
         if shifts is not None:
-            x = (x - self.x0 + shifts) % (self.xf - self.x0) + self.x0
+            # Shift is 0.0 for nonperiodic features.
+            x = (x - self.x0 + shifts)
+            # neural_spline_transformer expects periodic features to be within
+            # their domain.
+            x[:, self._circular] = x[:, self._circular] % (self.xf - self.x0)[self._circular]
+            # Re-shift to x0.
+            x = x + self.x0
 
         # Run rational quadratic spline.
         return neural_spline_transformer(x, self.x0, self._y0, widths, heights, slopes)
@@ -189,7 +195,13 @@ class NeuralSplineTransformer(MAFTransformer):
 
         # Shifts the periodic DOFs. Shifting is volume preserving.
         if shifts is not None:
-            x = (x - self.x0 - shifts) % (self.xf - self.x0) + self.x0
+            # Shift is 0.0 for nonperiodic features.
+            x = (x - self.x0 - shifts)
+            # neural_spline_transformer expects periodic features to be within
+            # their domain.
+            x[:, self._circular] = x[:, self._circular] % (self.xf - self.x0)[self._circular]
+            # Re-shift to x0.
+            x = x + self.x0
 
         return x, log_det_J
 

--- a/tfep/tests/nn/transformers/test_affine.py
+++ b/tfep/tests/nn/transformers/test_affine.py
@@ -49,16 +49,16 @@ def teardown_module(module):
 
 def get_random_input(batch_size, n_features, scale):
     """Create random input and parameters."""
-    n_parameters_per_input = 2 if scale else 1
+    n_parameters_per_feature = 2 if scale else 1
     x, coefficients = create_random_input(
         batch_size,
         n_features,
-        n_parameters=n_parameters_per_input*n_features,
+        n_parameters=n_parameters_per_feature*n_features,
         seed=0,
     )
 
-    # From (batch, n_parameters_per_input*n_features) to (batch, n_parameters_per_input, n_features).
-    coefficients = coefficients.reshape(batch_size, n_parameters_per_input, n_features)
+    # From (batch, n_parameters_per_feature*n_features) to (batch, n_parameters_per_feature, n_features).
+    coefficients = coefficients.reshape(batch_size, n_parameters_per_feature, n_features)
 
     # Divide features.
     shift = coefficients[:, 0]

--- a/tfep/tests/nn/transformers/test_mixed.py
+++ b/tfep/tests/nn/transformers/test_mixed.py
@@ -163,7 +163,7 @@ def test_mixed_transformer_get_identity_parameters(batch_size, transformers):
     parameters = mixed.get_identity_parameters(N_FEATURES).unsqueeze(0).expand(batch_size, -1)
     y, log_det_J = mixed(x, parameters)
     assert torch.allclose(x, y)
-    assert torch.allclose(log_det_J, torch.zeros_like(log_det_J))
+    assert torch.allclose(log_det_J, torch.zeros_like(log_det_J), atol=1e-7)
 
 
 @pytest.mark.parametrize('batch_size', BATCH_SIZES_TESTED)

--- a/tfep/tests/nn/transformers/test_spline.py
+++ b/tfep/tests/nn/transformers/test_spline.py
@@ -246,7 +246,14 @@ def test_identity_neural_spline(circular):
     # Create random input.
     x0 = torch.randn(n_features)
     xf = x0 + torch.abs(torch.randn(n_features))
-    x = torch.rand((batch_size, n_features)) * (xf - x0) + x0
+    x = torch.randn((batch_size, n_features)) * (xf - x0) + (x0 + xf) / 2
+
+    # Set the periodic features within their limits.
+    if circular is not False:
+        if circular is True:
+            x[:, :] = torch.rand((batch_size, n_features)) * (xf - x0) + x0
+        else:
+            x[:, circular] = torch.rand(x[:, circular].shape) * (xf - x0)[circular] + x0[circular]
 
     # Obtain identity parameters.
     transformer = NeuralSplineTransformer(x0=x0, xf=xf, n_bins=n_bins, circular=circular)

--- a/tfep/tests/nn/transformers/test_spline.py
+++ b/tfep/tests/nn/transformers/test_spline.py
@@ -44,7 +44,7 @@ def teardown_module(module):
 # REFERENCE IMPLEMENTATIONS
 # =============================================================================
 
-def reference_neural_spline(x, x0, y0, widths, heights, slopes):
+def reference_neural_spline(x, x0, y0, widths, heights, slopes, shifts=None):
     """A slow but simple implementation of neural_spline_transformer for testing."""
     x = x.detach().cpu().numpy()
     x0 = x0.detach().cpu().numpy()
@@ -52,13 +52,10 @@ def reference_neural_spline(x, x0, y0, widths, heights, slopes):
     widths = widths.detach().cpu().numpy()
     heights = heights.detach().cpu().numpy()
     slopes = slopes.detach().cpu().numpy()
+    if shifts is not None:
+        shifts = shifts.detach().cpu().numpy()
 
     batch_size, n_bins, n_features = widths.shape
-    n_knots = n_bins + 1
-
-    # Set the slope of the last knot if not given.
-    if slopes.shape[1] < n_knots:
-        slopes = np.concatenate([slopes, slopes[:, 0:1]], axis=1)
 
     knots_x = np.empty((batch_size, n_bins+1, n_features), dtype=x.dtype)
     knots_x[:, 0] = x0
@@ -72,7 +69,13 @@ def reference_neural_spline(x, x0, y0, widths, heights, slopes):
 
     for batch_idx in range(batch_size):
         for feat_idx in range(n_features):
-            bin_idx = np.digitize(x[batch_idx, feat_idx], knots_x[batch_idx, :, feat_idx], right=False) - 1
+            x_i = x[batch_idx, feat_idx]
+            bin_idx = np.digitize(x_i, knots_x[batch_idx, :, feat_idx], right=False) - 1
+
+            # Shift.
+            if shifts is not None:
+                x_i = x_i - x0[feat_idx] + shifts[batch_idx, feat_idx]
+                x_i = x_i % (knots_x[batch_idx, -1] - x0[feat_idx]) + x0[feat_idx]
 
             # If the value falls outside the limits, we transform linearly.
             if (bin_idx < 0) or (bin_idx == n_bins):
@@ -91,7 +94,7 @@ def reference_neural_spline(x, x0, y0, widths, heights, slopes):
                 deltak1 = slopes[batch_idx, bin_idx+1, feat_idx]
 
                 sk = (yk1 - yk) / (xk1 - xk)
-                epsilon = (x[batch_idx, feat_idx] - xk) / (xk1 - xk)
+                epsilon = (x_i - xk) / (xk1 - xk)
 
                 numerator = (yk1 - yk) * (sk * epsilon**2 + deltak * epsilon * (1 - epsilon))
                 denominator = sk + (deltak1 + deltak - 2*sk) * epsilon * (1 - epsilon)
@@ -108,48 +111,114 @@ def reference_neural_spline(x, x0, y0, widths, heights, slopes):
 # TESTS
 # =============================================================================
 
-@pytest.mark.parametrize('batch_size', [1, 4])
-@pytest.mark.parametrize('n_features', [2, 5, 8])
+@pytest.mark.parametrize('batch_size', [1, 5])
+@pytest.mark.parametrize('n_features', [1, 4])
+@pytest.mark.parametrize('n_bins', [2, 3])
+@pytest.mark.parametrize('circular', [False, True])
+@pytest.mark.parametrize('identity_boundary_slopes', [False, True])
+def test_neural_spline_get_parameters(batch_size, n_features, n_bins, circular, identity_boundary_slopes):
+    """The parameters are split correctly and the boundary slopes are set correctly."""
+    x0 = torch.full((n_features,), -1., dtype=torch.double, requires_grad=False)
+    xf = -x0
+
+    # Create the transformer.
+    transformer = NeuralSplineTransformer(
+        x0=x0,
+        xf=xf,
+        n_bins=n_bins,
+        circular=circular,
+        identity_boundary_slopes=identity_boundary_slopes,
+    )
+
+    # Verify the expected number of parameters.
+    n_parameters = (3*n_bins + 1) * n_features
+    if identity_boundary_slopes:
+        # In circular splines, the boundary slopes are equal but there is a
+        # shift parameter.
+        if circular:
+            n_parameters -= n_features
+        else:
+            n_parameters -= 2 * n_features
+    assert len(transformer.get_identity_parameters(n_features)) == n_parameters
+
+    # Create random parameters.
+    x, parameters = create_random_input(
+        batch_size,
+        n_features,
+        n_parameters=n_parameters,
+        x_func=torch.randn,
+    )
+
+    # Process the parameters.
+    widths, heights, slopes, shifts = transformer._get_parameters(parameters)
+
+    # The lengths of the parameters are correct.
+    assert widths.shape == (batch_size, n_bins, n_features)
+    assert heights.shape == (batch_size, n_bins, n_features)
+    assert slopes.shape == (batch_size, n_bins+1, n_features)
+
+    # For circular splines, the shift parameter is present.
+    if circular:
+        assert shifts.shape == (batch_size, n_features)
+    else:
+        assert shifts is None
+
+    # The boundary slopes are correct.
+    if identity_boundary_slopes:
+        assert torch.allclose(slopes[:, 0], torch.ones_like(slopes[:, 0]))
+        assert torch.allclose(slopes[:, -1], torch.ones_like(slopes[:, 0]))
+    if circular:
+        assert torch.allclose(slopes[:, 0], slopes[:, -1])
+
+
+@pytest.mark.parametrize('batch_size', [1, 3])
+@pytest.mark.parametrize('n_features', [1, 4])
 @pytest.mark.parametrize('x0', [-2, -1])
 @pytest.mark.parametrize('y0', [1, 2])
-@pytest.mark.parametrize('n_bins', [2, 3, 5])
-def test_neural_spline_transformer_reference(batch_size, n_features, x0, y0, n_bins):
+@pytest.mark.parametrize('n_bins', [2, 5])
+@pytest.mark.parametrize('circular', [False, True])
+@pytest.mark.parametrize('identity_boundary_slopes', [False, True])
+def test_neural_spline_transformer_reference(batch_size, n_features, x0, y0, n_bins, circular, identity_boundary_slopes):
     """Compare PyTorch and reference implementation of neural spline transformer."""
-    # Determine the first and final knots of the spline. We
-    # arbitrarily set the domain of the first dimension to 0.0
-    # to test different dimensions for different features.
+    # Determine the first and final knots of the spline. We arbitrarily set the
+    # domain of the first dimension to 0.0 to test different dimensions for
+    # different features.
     x0 = torch.full((n_features,), x0, dtype=torch.double, requires_grad=False)
     xf = -x0
     xf[0] = 0
     y0 = torch.full((n_features,), y0, dtype=torch.double, requires_grad=False)
     yf = y0 + xf - x0
 
-    # Create widths, heights, and slopes of the bins.
+    # Deactivate minimum bin size/slope which are not implemented in the reference.
+    transformer = NeuralSplineTransformer(x0, xf, n_bins, y0, yf,
+                                          min_bin_size=1e-12, min_slope=1e-12)
+
+    # Create random input. Periodic inputs are expected within the domain.
     x, parameters = create_random_input(
         batch_size,
         n_features,
-        n_parameters=(3*n_bins+1) * n_features,
+        n_parameters=transformer.n_parameters_per_input*n_features,
         seed=0,
-        x_func=torch.randn,
+        x_func=torch.rand if circular else torch.randn,
     )
-    parameters = parameters.reshape(batch_size, -1, n_features)
+    if circular:
+        # x is now between 0 and 1. Scale and shift to match the spline domain.
+        x = (x * (xf - x0) + x0)
+        assert torch.all(x >= x0) and torch.all(x <= xf)
+    else:
+        # x is now distributed around 0. We center it and scale it so that the
+        # most of the values are between x0 and xf. We detach to make the new x
+        # a leaf variable and reset requires_grad.
+        x = (x * (xf - x0) + (x0 + xf) / 2)
 
-    # The parameters for the reference function.
-    widths = torch.nn.functional.softmax(parameters[:, :n_bins], dim=1) * (xf - x0)
-    heights = torch.nn.functional.softmax(parameters[:, n_bins:2*n_bins], dim=1) * (yf - y0)
-    offset = torch.log(torch.tensor(np.e) - 1.)
-    slopes = torch.nn.functional.softplus(parameters[:, 2*n_bins:] + offset)
-
-    # x is now distributed around 0. We center it and scale it so that the most
-    # of the values are between x0 and xf. We detach to make the new x a leaf
-    # variable and reset requires_grad.
-    x = (x * (xf - x0) + (x0 + xf) / 2).detach()
+    # Set requires_grad to check the log_det_J against autograd.
+    x = x.detach()
     x.requires_grad = True
 
-    # Run the transformer. Deactivate minimum bin size/slope which are not
-    # implemented in the reference.
-    transformer = NeuralSplineTransformer(x0, xf, n_bins, y0, yf,
-                                          min_bin_size=1e-12, min_slope=1e-12)
+    # The parameters for the reference function.
+    widths, heights, slopes, shifts = transformer._get_parameters(parameters)
+
+    # Test the result against the reference implementation.
     torch_y, torch_log_det_J = transformer(x, parameters)
     ref_y, ref_log_det_J = reference_neural_spline(x, x0, y0, widths, heights, slopes)
     assert np.allclose(ref_y, torch_y.detach().cpu().numpy())
@@ -175,30 +244,18 @@ def test_neural_spline_transformer_reference(batch_size, n_features, x0, y0, n_b
     assert torch.allclose(ref_log_det_J_inv, log_det_J_inv)
 
 
-@pytest.mark.parametrize('circular', [
-    True,
-    torch.tensor([0]),
-    torch.tensor([1]),
-    torch.tensor([0, 1]),
-    torch.tensor([1, 2]),
-])
-def test_circular_spline_transformer_periodic(circular):
+def test_circular_spline_transformer_periodic():
     """Test that circular spline transformer conditions for periodicity are verified."""
     batch_size = 5
     n_features = 3
     n_bins = 3
 
-    if circular is True:
-        circular_indices = torch.arange(n_features)
-    else:
-        circular_indices = circular
-
     # Input lower/upper boundaries.
     x0 = torch.tensor([0.0, -1, 2])
     xf = torch.tensor([2.0, -0.5, 5])
 
-    # Create input. The first and last batch are the lower and upper boundaries
-    # respectively. The last batches are random.
+    # Create input. The first and second batches are the lower and upper
+    # boundaries, respectively. The last batches are random.
     epsilon = 1e-8
     x = torch.cat([
         x0.unsqueeze(0) + epsilon,
@@ -210,12 +267,12 @@ def test_circular_spline_transformer_periodic(circular):
     parameters = torch.randn((batch_size, (3*n_bins+1) * n_features))
 
     # Create and run the transformer.
-    transformer = NeuralSplineTransformer(x0=x0, xf=xf, n_bins=n_bins, circular=circular)
+    transformer = NeuralSplineTransformer(x0=x0, xf=xf, n_bins=n_bins, circular=True)
     y, log_det_J = transformer(x, parameters)
 
     # The slopes of the first and last knots must be the same.
     _, _, slopes, shifts = transformer._get_parameters(parameters)
-    assert torch.allclose(slopes[:, 0, circular_indices], slopes[:, -1, circular_indices])
+    assert torch.allclose(slopes[:, 0], slopes[:, -1])
 
     # The random input are still within boundaries
     assert torch.all(x0 < y)
@@ -227,39 +284,36 @@ def test_circular_spline_transformer_periodic(circular):
     assert torch.allclose(log_det_J+log_det_J_inv, torch.zeros_like(log_det_J))
 
     # If the shifts are 0.0, the boundaries must be mapped to themselves.
-    parameters.reshape(batch_size, -1, n_features)[:, 3*n_bins, circular_indices] = 0.0
+    parameters.reshape(batch_size, -1, n_features)[:, 3*n_bins] = 0.0
     y, log_det_J = transformer(x, parameters.reshape(batch_size, -1))
     assert torch.allclose(x[:2], y[:2], atol=10*epsilon)
 
 
-@pytest.mark.parametrize('circular', [
-    False,
-    True,
-    torch.tensor([0]),
-    torch.tensor([1]),
-    torch.tensor([0, 2]),
-    torch.tensor([1, 2]),
-])
-def test_identity_neural_spline(circular):
+@pytest.mark.parametrize('batch_size', [1, 3])
+@pytest.mark.parametrize('n_features', [1, 4])
+@pytest.mark.parametrize('n_bins', [2, 5])
+@pytest.mark.parametrize('circular', [False, True])
+@pytest.mark.parametrize('identity_boundary_slopes', [False, True])
+def test_identity_neural_spline(batch_size, n_features, n_bins, circular, identity_boundary_slopes):
     """Test that get_identity_parameters returns the correct parameters for the identity function."""
-    batch_size = 5
-    n_features = 3
-    n_bins = 3
-
-    # Create random input.
     x0 = torch.randn(n_features)
-    xf = x0 + torch.abs(torch.randn(n_features))
-    x = torch.randn((batch_size, n_features)) * (xf - x0) + (x0 + xf) / 2
+    xf = x0 + torch.abs(torch.rand(n_features)) + 1.
 
-    # Set the periodic features within their limits.
-    if circular is not False:
-        if circular is True:
-            x[:, :] = torch.rand((batch_size, n_features)) * (xf - x0) + x0
-        else:
-            x[:, circular] = torch.rand(x[:, circular].shape) * (xf - x0)[circular] + x0[circular]
+    # Create random input. For circular splines, the input is expected to be
+    # within the spline domain.
+    if circular:
+        x = torch.rand((batch_size, n_features)) * (xf - x0) + x0
+    else:
+        x = torch.randn((batch_size, n_features)) * (xf - x0) + (x0 + xf) / 2
 
     # Obtain identity parameters.
-    transformer = NeuralSplineTransformer(x0=x0, xf=xf, n_bins=n_bins, circular=circular)
+    transformer = NeuralSplineTransformer(
+        x0=x0,
+        xf=xf,
+        n_bins=n_bins,
+        circular=circular,
+        identity_boundary_slopes=identity_boundary_slopes,
+    )
     parameters = transformer.get_identity_parameters(n_features)
     # We need to clone to actually allocate the memory or sliced
     # assignment operations on parameters won't work.

--- a/tfep/tests/nn/transformers/test_spline.py
+++ b/tfep/tests/nn/transformers/test_spline.py
@@ -197,7 +197,7 @@ def test_neural_spline_transformer_reference(batch_size, n_features, x0, y0, n_b
     x, parameters = create_random_input(
         batch_size,
         n_features,
-        n_parameters=transformer.n_parameters_per_input*n_features,
+        n_parameters=transformer.n_parameters_per_feature*n_features,
         seed=0,
         x_func=torch.rand if circular else torch.randn,
     )

--- a/tfep/tests/nn/transformers/test_spline.py
+++ b/tfep/tests/nn/transformers/test_spline.py
@@ -428,8 +428,8 @@ def test_min_bin_and_slopes(
 
     # Create the spline.
     transformer = NeuralSplineTransformer(
-        x0=torch.tensor([x0]*n_features),
-        xf=torch.tensor([xf]*n_features),
+        x0=torch.tensor(x0),
+        xf=torch.tensor(xf),
         n_bins=n_bins,
         circular=circular,
         identity_boundary_slopes=identity_boundary_slopes,


### PR DESCRIPTION
Several improvements to the neural spline transformer.

**API-breaking changes**
- Drop support for partially circular neural spline transformer to simplify the logic and enable the new features in this PR. Partially circular neural splines can still be implemented through the ``MixedTransformer``.
- Renamed property ``n_parameters_per_input`` to ``n_parameters_per_feature`` for consistency with the rest of the API and docs.

**New features**
- Neural splines are defined outside their domain as linear functions. The slopes of the boundary nodes can be forced to 1, which makes the transformer equal to the identity function outside the spline domain when ``x0==y0`` and ``xf==yf``.
- The neural spline domain can be learned.

**Enhancements**
- Minimum bin and slope is guaranteed to improve the numerical stability.