### PR TITLE
MixedMAFMap maps rototranslational DOFs, MixedEmbedding, FlipInvariantEmbedding, and QuaternionProductTransformer

### DIFF
--- a/tfep/app/base.py
+++ b/tfep/app/base.py
@@ -685,12 +685,6 @@ class TFEPMapBase(ABC, lightning.LightningModule):
                     raise ValueError('Selected multiple atoms as the origin atom')
                 origin_atom_idx = origin_atom_idx[0]
 
-            # Make sure origin is a fixed atom.
-            if (conditioning_atom_indices is None or
-                        origin_atom_idx not in conditioning_atom_indices):
-                raise ValueError("origin_atom is not a conditioning atom. origin_atom "
-                                 "affects the mapping but its position is constrained.")
-
         # Select axes atoms.
         if axes is None:
             axes_atoms_indices = None

--- a/tfep/app/cartesianmaf.py
+++ b/tfep/app/cartesianmaf.py
@@ -310,6 +310,16 @@ class CartesianMAFMap(TFEPMapBase):
             indices = self._remove_reference_indices(indices, idx_type=idx_type, remove_fixed=remove_fixed)
         return indices
 
+    def determine_atom_indices(self):
+        """Override CartesianMAFMap.determine_atom_indices to check that the origin atom is conditioning."""
+        super().determine_atom_indices()
+
+        # Make sure origin is a fixed atom.
+        if (self._conditioning_atom_indices is None or
+                    self._origin_atom_idx not in self._conditioning_atom_indices):
+            raise ValueError("origin_atom is not a conditioning atom. origin_atom "
+                             "affects the mapping but its position is constrained.")
+
     def _remove_reference_indices(
             self,
             indices: torch.Tensor,

--- a/tfep/app/cartesianmaf.py
+++ b/tfep/app/cartesianmaf.py
@@ -21,7 +21,7 @@ import torch
 from tfep.app.base import TFEPMapBase
 import tfep.nn.conditioners.made
 import tfep.nn.flows
-from tfep.utils.misc import atom_to_flattened_indices
+from tfep.utils.misc import atom_to_flattened_indices, remove_and_shift_sorted_indices
 
 
 # =============================================================================
@@ -349,17 +349,8 @@ class CartesianMAFMap(TFEPMapBase):
 
         # Remove the reference atom indices.
         if len(removed_indices) > 0:
-            # removed_indices must be sorted for searchsorted.
+            # removed_indices must be sorted for remove_and_shift_sorted_indices.
             removed_indices = torch.cat(removed_indices).sort()[0]
-
-            # We need to first to delete the constrained reference DOFs that belong to indices.
-            mask = True
-            for idx in removed_indices:
-                mask &= indices != idx
-            indices = indices[mask]
-
-            # And now shift the indices to account for the removal of the
-            # constrained indices (even if they don't belong to indices).
-            indices = indices - torch.searchsorted(removed_indices, indices)
+            indices = remove_and_shift_sorted_indices(indices, removed_indices)
 
         return indices

--- a/tfep/app/mixedmaf.py
+++ b/tfep/app/mixedmaf.py
@@ -38,6 +38,7 @@ from tfep.utils.misc import (
     atom_to_flattened_indices,
     atom_to_flattened,
     flattened_to_atom,
+    ensure_tensor_sequence,
     remove_and_shift_sorted_indices,
 )
 
@@ -61,9 +62,10 @@ class MixedMAFMap(TFEPMapBase):
     atoms are not mapped but are given as input to the flow to condition the
     mapping. Fixed atoms are instead ignored.
 
-    The coordinates of the mapped molecules are transformed into a mixed
-    Cartesian/internal coordinate representation based on a Z-matrix before going
-    through the MAF.
+    Before going through the MAF, the coordinates of are transformed into a mixed
+    Cartesian/internal coordinate system. To this end, the system is first
+    divided into connected fragments based on the bond topology, and a separate
+    Z-matrix is built for each fragment.
 
     The Z-matrix is automatically determined based on a heuristic. The first atom
     is chosen as the center of the graph representing the molecule. The graph is
@@ -79,14 +81,21 @@ class MixedMAFMap(TFEPMapBase):
     are represented as Cartesian, while the remaining mapped atoms are converted
     to internal coordinates.
 
-    Optionally, the flow can map the atoms in a relative frame of reference
-    which based on the position of an ``origin_atom`` and two ``axes_atoms``
-    that determine the origin and the orientation of the axes, respectively.
-    When given, these atoms are prioritized for the choice of the first three
-    atoms of a molecule's Z-matrix. Furthermore, if ``auto_reference_frame``
-    is set to ``True``, the class will determine the frame of reference automatically
-    based on the first three atoms of the Z-matrix. In this case, if the origin
-    atom is mapped, it will be automatically set to be conditioning.
+    The flow also rototranslates the Cartesian coordinates into a relative
+    frame of reference which based on the position of an ``origin_atom`` and
+    two ``axes_atoms`` that determine the origin and the orientation of the
+    axes, respectively. When given, these atoms are prioritized for the choice
+    of the first three atoms of a molecule's Z-matrix. If not passed, these 3
+    atoms are automatically chosen as the first three atoms in the Z-matrix of
+    the largest fragment. Optionally, the roto-translational degrees of freedom
+    can be removed from the mapping with ``remove_translation`` and
+    ``remove_rotation``.
+
+    When ``remove_rotation is True`` the ``axes_atoms`` are represented in
+    internal coordinates (2 distances w.r.t. the origin atom and 1 angle).
+    When ``False``, the axis/plane atoms are represented in Cartesian/cylindrical
+    coordinates. This is just because it simplifies the support for removing
+    the global rotational degrees of freedom with ``remove_rotation``.
 
     The class further supports logging the potential energies computed during
     training (required for the multimap TFEP analysis) and mid-epoch resuming.
@@ -140,8 +149,9 @@ class MixedMAFMap(TFEPMapBase):
             conditioning_atoms: Optional[Union[Sequence[int], str]] = None,
             origin_atom: Optional[Union[int, str]] = None,
             axes_atoms: Optional[Union[Sequence[int], str]] = None,
+            remove_translation: bool = False,
+            remove_rotation: bool = False,
             tfep_logger_dir_path: str = 'tfep_logs',
-            auto_reference_frame: bool = False,
             n_maf_layers: int = 6,
             distance_lower_limit_displacement: Optional[pint.Quantity] = None,
             dataloader_kwargs: Optional[Dict] = None,
@@ -171,17 +181,17 @@ class MixedMAFMap(TFEPMapBase):
             The indices (0-based) of the atoms to map or a selection string in
             MDAnalysis syntax. If not passed, all atoms that are not conditioning
             are mapped (i.e., all atoms are mapped if also ``conditioning_atoms``
-            is not given.
+            is not given).
         conditioning_atoms : Sequence[int] or str, optional
             The indices (0-based) of the atoms conditioning the mapping or a
             selection string in MDAnalysis syntax. If not passed, no atom will
-            condition the map.
+            condition the map. These atoms cannot overlap with ``mapped_atoms``.
         origin_atom : int or str or None, optional
             The index (0-based) or a selection string in MDAnalysis syntax of an
             atom on which to center the origin of the relative frame of reference.
-            While this atom affects the mapping of the mapped atoms, its position
-            will be constrained during the mapping, and thus it must be a conditioning
-            atom by definition.
+            If a conditioning atom, the coordinates are not passed to the flow
+            as they would be always zero. By default, this is chosen as the 1st
+            atom in the Z-matrix of the largest fragment.
         axes_atoms : Sequence[int] or str or None, optional
             A pair of indices (0-based) or a selection string in MDAnalysis syntax
             for the two atoms determining the relative frame of reference. The
@@ -190,23 +200,24 @@ class MixedMAFMap(TFEPMapBase):
             and ``z`` axes. The ``y`` axis will be set as the cross product of
             ``x`` and ``y``.
 
-            These atoms can be either conditioning or mapped. ``axes_atoms[0]``
-            has only 1 degree of freedom (DOF) while ``axes_atoms[1]`` has 2.
-            Whether these DOFs are mapped or not depends on whether their atoms
-            are indicated as mapped or conditioning, respectively.
+            If conditioning atoms, the coordinates that after the rotation are
+            0 are not passed to the flow. The other degrees of freedom are
+            converted into two distances (from the origin atom) and a valence
+            angle. By default, these are chosen as the 2nd and 3rd atoms in the
+            Z-matrix of the largest fragment.
+        remove_translation : bool, optional
+            If ``True``, the 3 degrees of freedom of the ``origin_atom`` are
+            not mapped even if ``origin_atom`` is mapped. When ``origin_atom``
+            is conditioning, this option has no effect.
+        remove_rotation : bool, optional
+            If ``True``, the 3 rotational degrees of freedom of ``axes_atoms``
+            are not mapped even if ``axes_atoms`` are mapped atoms. In this
+            case, only their 2 distances from the origin atom and the valence
+            angle between them is passed to the flow. When ``axes_atoms`` are
+            conditioning, this option has no effect.
         tfep_logger_dir_path : str, optional
             The path where to save TFEP-related information (potential energies,
             sample indices, etc.).
-        auto_reference_frame : bool, optional
-            If ``True``, the class automatically determines a relative frame of
-            reference based on the first three atoms entering the Z-matrix. Both
-            ``origin_atom`` and ``axes_atoms`` must be ``None`` for this. Note
-            that the origin atom, if mapped, will become effectively conditioning
-            because its position will be maintained.
-
-            This is useful, for example, in vacuum, where the potential is invariant
-            to rototranslations of the molecule and the system effectively has 3*N-6
-            degrees of freedom.
         n_maf_layers : int, optional
             The number of MAF layers.
         distance_lower_limit_displacement : pint.Quantity or None
@@ -218,7 +229,7 @@ class MixedMAFMap(TFEPMapBase):
             Angstrom.
 
             Note that the same maximum displacement is applied to control the
-            two distances between the two axes atoms from the origin.
+            two distances between the axes atoms and the origin.
         dataloader_kwargs : Dict, optional
             Extra keyword arguments to pass to ``torch.utils.data.DataLoader``.
         **kwargs
@@ -230,8 +241,8 @@ class MixedMAFMap(TFEPMapBase):
 
         """
         # Check input.
-        if auto_reference_frame and (origin_atom is not None or axes_atoms is not None):
-            raise ValueError('With auto_reference_frame=True both origin_atom and axes_atoms must be None.')
+        if axes_atoms is not None and origin_atom is None:
+            raise ValueError('axes_atoms cannot be passed if origin_atom is None.')
 
         # Convert bond
         super().__init__(
@@ -256,7 +267,7 @@ class MixedMAFMap(TFEPMapBase):
 
         # Save hyperparameters.
         self.hparams['distance_lower_limit_displacement'] = distance_lower_limit_displacement
-        self.save_hyperparameters('n_maf_layers', 'auto_reference_frame')
+        self.save_hyperparameters('n_maf_layers', 'remove_translation', 'remove_rotation')
 
         # MAF kwargs.
         self._kwargs = kwargs
@@ -277,16 +288,27 @@ class MixedMAFMap(TFEPMapBase):
             raise ValueError('There are no internal coordinates to map. '
                              'Consider using a Cartesian flow.')
 
+        # If the origin and orientation atoms are conditioning, we remove the
+        # rototranslational DOFs in the coordinate conversion since they are constant.
+        reference_atom_indices = self.get_reference_atoms_indices(remove_fixed=True)
+        conditioning_atom_indices = self.get_conditioning_indices(idx_type='atom', remove_fixed=True)
+        if conditioning_atom_indices is None:
+            is_ref_conditioning = [False, False, False]
+        else:
+            is_ref_conditioning = torch.isin(reference_atom_indices, conditioning_atom_indices).tolist()
+
         # Initialize _CartesianToMixedFlow that will map the MAF. We will set
         # the wrapped flow after we have initialized the MAF.
-        origin_atom_idx, axes_atoms_indices = self.get_reference_atoms_indices(
-            remove_fixed=True, separate_origin_axes=True)
         cartesian_to_mixed_flow = _CartesianToMixedFlow(
             flow=None,
             cartesian_atom_indices=cartesian_atom_indices,
             z_matrix=z_matrix,
-            origin_atom_idx=origin_atom_idx,
-            axes_atoms_indices=axes_atoms_indices,
+            reference_atom_indices=reference_atom_indices,
+            remove_ref_rototranslation=[
+                self.hparams.remove_translation or is_ref_conditioning[0],
+                self.hparams.remove_rotation or is_ref_conditioning[1],
+                self.hparams.remove_rotation or is_ref_conditioning[2],
+            ],
         )
 
         # Now we take a pass at the trajectory to check that the Z-matrix is robust
@@ -295,43 +317,36 @@ class MixedMAFMap(TFEPMapBase):
         # neural splines correctly.
         min_dof_vals, max_dof_vals = self._analyze_dataset(z_matrix, cartesian_to_mixed_flow)
 
-        # Determine the conditioning DOFs after going through _CartesianToMixedFlow.
-        # conditioning_atom_indices must have the indices after the fixed atoms are removed.
-        conditioning_atom_indices = self.get_conditioning_indices(idx_type='atom', remove_fixed=True)
-
-        maf_conditioning_dof_indices = cartesian_to_mixed_flow.get_maf_conditioning_dof_indices(
-            conditioning_atom_indices=conditioning_atom_indices)
-
-        # Determine the angles degrees of freedom (i.e., angles and torsions)
-        # to pass to the MAF layer. Only torsions are periodic as angles are
-        # in [0, pi].
-        maf_valence_angles_dof_indices, maf_torsions_dof_indices = cartesian_to_mixed_flow.get_maf_angles_dof_indices()
+        # Determine the various types of degrees of freedom after the
+        # conversion from Cartesian to mixed coordinates.
+        maf_dof_indices = cartesian_to_mixed_flow.get_dof_indices_by_type(conditioning_atom_indices)
 
         # Create the transformer.
         transformer = self._get_transformer(
             cartesian_to_mixed_flow=cartesian_to_mixed_flow,
             min_dof_vals=min_dof_vals,
             max_dof_vals=max_dof_vals,
-            maf_conditioning_dof_indices=maf_conditioning_dof_indices,
-            maf_valence_angles_dof_indices=maf_valence_angles_dof_indices,
-            maf_torsions_dof_indices=maf_torsions_dof_indices,
+            dof_indices=maf_dof_indices,
+        )
+
+        # Create the degrees_in argument for ascending (index 0) and descending
+        # (index 1) order.
+        degrees_in = self._get_maf_degrees_in(
+            n_dofs_in=cartesian_to_mixed_flow.n_dofs_out,
+            maf_dof_indices=maf_dof_indices
         )
 
         # Build MAF layers.
         maf_layers = []
         for layer_idx in range(self.hparams.n_maf_layers):
             maf_layers.append(tfep.nn.flows.MAF(
-                degrees_in=tfep.nn.conditioners.made.generate_degrees(
-                    n_features=self.n_nonfixed_dofs,
-                    conditioning_indices=maf_conditioning_dof_indices,
-                    order='ascending' if (layer_idx%2 == 0) else 'descending',
-                ),
+                degrees_in=degrees_in[layer_idx%2],
                 transformer=transformer,
                 embedding=tfep.nn.embeddings.PeriodicEmbedding(
-                    n_features_in=self.n_nonfixed_dofs,
-                    periodic_indices=maf_torsions_dof_indices,
+                    n_features_in=cartesian_to_mixed_flow.n_dofs_out,
                     # The periodic limits are 0 to 1 if normalize_angles=True in _CartesianToMixedFlow
                     limits=[0, 1],
+                    periodic_indices=maf_dof_indices['torsions'],
                 ),
                 **self._kwargs,
             ))
@@ -342,23 +357,23 @@ class MixedMAFMap(TFEPMapBase):
         return cartesian_to_mixed_flow
 
     def _build_z_matrix(self):
-        """Determine the Z-matrix, the Cartesian atoms, and (optionally) the automatic frame of reference.
+        """Determine the Z-matrix, the Cartesian atoms, and (if not given) the reference frame atoms.
 
         See the class docstring for an overview of how the Z-matrix is determined.
 
         The Z-matrix is constructed so that the origin and axes atoms are always
         included among the Cartesian atoms.
 
-        If self.hparams.auto_reference_frame is True, this method also sets
-        self._origin_atom_idx and self._axes_atoms_indices.
+        If not given by the user, this method also sets self._origin_atom_idx
+        and self._axes_atoms_indices.
 
         Returns
         -------
-        cartesian_atom_indices : numpy.ndarray
+        cartesian_atom_indices : list[int]
             Shape (n_cartesian_atoms,). The indices of the atoms represented by
             Cartesian coordinates (i.e., 3 reference atoms for each molecule,
             and all conditioning atoms). The array is sorted in ascending order.
-        z_matrix : numpy.ndarray
+        z_matrix : list[list[int]]
             Shape (n_ic_atoms, 4). The Z-matrix for the atoms represented by
             internal coordinates. E.g., ``z_matrix[i] == [7, 2, 4, 8]``
             means that the distance, angle, and dihedral for atom ``7`` must be
@@ -387,87 +402,100 @@ class MixedMAFMap(TFEPMapBase):
         else:
             ref_atom_indices = ref_atom_indices.tolist()
 
+        nonfixed_atom_indices_w_fixed = nonfixed_atom_indices_w_fixed.tolist()
+        if not set(ref_atom_indices).issubset(set(nonfixed_atom_indices_w_fixed)):
+            raise ValueError('The origin and axes atoms must be mapped or conditioning.')
+
         # Only the mapped atoms are represented using internal coordinates
         # so we build a set to check for membership.
         mapped_atom_indices_w_fixed_set = set(mapped_atom_indices_w_fixed.tolist())
 
-        # Initialize returned values.
-        cartesian_atom_indices = []
-        system_z_matrix = []
-
         # Build the Z-matrix for each connected subgraph.
+        frags_z_matrices = []
         for graph_nodes in nx.connected_components(system_graph):
             graph = system_graph.subgraph(graph_nodes).copy()
+            frags_z_matrices.append(self._build_connected_graph_z_matrix(graph, ref_atom_indices))
 
-            # Check if this molecule is composed only by conditioning atoms.
-            graph_atom_indices = [node.ix for node in graph]
-            if len(set(graph_atom_indices).intersection(mapped_atom_indices_w_fixed_set)) == 0:
-                # Add everything to Cartesian atoms.
-                cartesian_atom_indices.extend(graph_atom_indices)
+        # If not given, automatically determine the frame of reference. We need
+        # to do it before we shift the indices to account for the removed fixed
+        # atoms and before we remove the first three rows of the Z-matrix since
+        # in the 4th row the order of origin/axes atoms is scrambled.
+        z_matrix = frags_z_matrices[np.argmax([len(z) for z in frags_z_matrices])]
+        if self._origin_atom_idx is None:
+            self._origin_atom_idx = torch.tensor(z_matrix[0][0])
+        if self._axes_atoms_indices is None:
+            self._axes_atoms_indices = torch.tensor([z_matrix[1][0], z_matrix[2][0]])
 
-                # Skip to next molecule.
-                continue
+        # Divide atoms treated as Cartesian and internal coords.
+        cartesian_atom_indices = []
+        ic_z_matrix = []
+        for z_matrix in frags_z_matrices:
+            # First three atoms of each Z-matrix are Cartesian.
+            cartesian_atom_indices.extend([row[0] for row in z_matrix[:3]])
 
-            # Build the Z-matrix for this molecule.
-            graph_z_matrix = self._build_connected_graph_z_matrix(graph, ref_atom_indices)
-
-            # If requested, automatically determine the frame of reference. We need
-            # to do it before we shift the indices to account for the removed fixed
-            # atoms and before we remove the first three rows of the Z-matrix since
-            # in the 4th row the order of origin/axes atoms is scrambled.
-            if self.hparams.auto_reference_frame and self._origin_atom_idx is None:
-                self._determine_reference_frame_atoms(graph_z_matrix, mapped_atom_indices_w_fixed_set)
-
-            # Now separate the Cartesian atoms from the Z-matrix ones. First three
-            # atoms are always Cartesian (or determine the automatic reference frame).
-            cartesian_atom_indices.extend([row[0] for row in graph_z_matrix[:3]])
-
-            # Only the mapped atoms are mapped as internal coordinates.
-            for z_matrix_row in graph_z_matrix[3:]:
+            # Only the mapped atoms are converted to internal coordinates.
+            # Conditioning atoms are kept as Cartesian.
+            is_mapped = False
+            for z_matrix_row in z_matrix[3:]:
                 if z_matrix_row[0] in mapped_atom_indices_w_fixed_set:
-                    system_z_matrix.append(z_matrix_row)
+                    ic_z_matrix.append(z_matrix_row)
+                    is_mapped = True
                 else:
                     cartesian_atom_indices.append(z_matrix_row[0])
 
-            # Test independence.
-            check_independent(graph_z_matrix)
+            # Test independence. No need to check purely conditioning fragments.
+            if is_mapped:
+                check_independent(z_matrix)
 
         # The atom indices and the Z-matrix so far use the atom indices of the
         # systems before the fixed and reference atoms have been removed. Now
         # we need to map the indices to those after they are removed since these
-        # are not passed to _CartesianToMixed._rel_ic.
-        nonfixed_atom_indices_w_fixed = nonfixed_atom_indices_w_fixed.tolist()
+        # are not passed to _CartesianToMixed.rel_ic.
         indices_map = {nonfixed_atom_indices_w_fixed[idx]: idx for idx in range(self.n_nonfixed_atoms)}
 
         # Log Z-matrix.
-        logger.info('Determined Z-Matrix:\n' + str(np.array(system_z_matrix)))
+        logger.info('Determined Z-Matrix:\n' + str(np.array(ic_z_matrix)))
 
         # Convert indices.
         cartesian_atom_indices = [indices_map[i] for i in cartesian_atom_indices]
-        for row_idx, z_matrix_row in enumerate(system_z_matrix):
-            system_z_matrix[row_idx] = [indices_map[i] for i in z_matrix_row]
+        for row_idx, z_matrix_row in enumerate(ic_z_matrix):
+            ic_z_matrix[row_idx] = [indices_map[i] for i in z_matrix_row]
 
         # Sort atom indices and convert everything to numpy array (for RelativeInternalCoordinateTransformation).
-        cartesian_atom_indices = np.array(cartesian_atom_indices)
-        cartesian_atom_indices.sort()
-        return cartesian_atom_indices, np.array(system_z_matrix)
+        cartesian_atom_indices = torch.tensor(cartesian_atom_indices).sort().values
+        return cartesian_atom_indices, torch.tensor(ic_z_matrix)
 
     def _create_networkx_graph(self, atom_indices):
         """Return a networkx graph representing the given atoms."""
         # Select only the bonds in which both atoms are in the atom group.
-        nonfixed_atoms = MDAnalysis.AtomGroup(atom_indices, self.dataset.universe)
-        internal_bonds = [bond for bond in nonfixed_atoms.bonds
-                          if (bond.atoms[0] in nonfixed_atoms and bond.atoms[1] in nonfixed_atoms)]
+        atoms = MDAnalysis.AtomGroup(atom_indices, self.dataset.universe)
+        bonds = [bond for bond in atoms.bonds
+                 if (bond.atoms[0] in atoms and bond.atoms[1] in atoms)]
 
         # Build a networkx graph representing the topology of all the nonfixed atoms.
-        system_graph = nx.Graph()
-        system_graph.add_nodes_from(nonfixed_atoms)
-        system_graph.add_edges_from(internal_bonds)
+        graph = nx.Graph()
+        graph.add_nodes_from(atoms)
+        graph.add_edges_from(bonds)
 
-        return system_graph
+        return graph
 
     def _build_connected_graph_z_matrix(self, graph, ref_atom_indices):
-        """Build the Z-matrix for a connected graph."""
+        """Build the Z-matrix for a connected graph.
+
+        Parameters
+        ----------
+        graph : networkx.Graph
+            The graph with nodes and edges representing atoms and bonds.
+        ref_atom_indices : list[int]
+            The user-given reference atoms. These are prioritized when
+            selecting the initial 3 atoms of the Z-matrix.
+
+        Returns
+        -------
+        z_matrix : list[list[int]]
+            The returned Z-matrix.
+
+        """
         # For the first three atoms, we give priority to the user-defined
         # origin/axes atoms as long as they are within the molecule.
         ref_atoms_in_graph = [self.dataset.universe.atoms[i] for i in ref_atom_indices
@@ -586,54 +614,9 @@ class MixedMAFMap(TFEPMapBase):
         priorities.sort(key=lambda k: tuple(k[1:]))
         return priorities
 
-    def _determine_reference_frame_atoms(self, z_matrix_w_fixed: List[int], mapped_atom_indices_w_fixed_set: Set[int]):
-        """If requested, determine the origin and axes atoms.
-
-        Both z_matrix and mapped_atom_indices must hold the indices of the atoms
-        before the fixed atoms are removed.
-
-        If the automatically-determined origin atom is a mapped atom, this converts
-        it to a conditioning atom and updates the self._mapped_atom_indices,
-        self._conditioning_atom_indices, and the argument mapped_atom_indices_w_fixed_set.
-
-        """
-        if not self.hparams.auto_reference_frame:
-            return
-        assert self._origin_atom_idx is None
-        assert self._axes_atoms_indices is None
-
-        # Set origin and axes atom indices as the first three atoms of the Z-matrix.
-        # Keep Python integer value of origin idx before converting to tensor.
-        origin_atom_idx = z_matrix_w_fixed[0][0]
-        self._origin_atom_idx = torch.tensor(origin_atom_idx)
-        self._axes_atoms_indices = torch.tensor([z_matrix_w_fixed[1][0], z_matrix_w_fixed[2][0]])
-
-        # If the origin atom is mapped, we move it to the conditioning atom for consistency.
-        if origin_atom_idx in mapped_atom_indices_w_fixed_set:
-            logger.warning(f'Converting atom {origin_atom_idx} from mapped to conditioning '
-                           'because it has been selected as the origin for the automatically '
-                           'determined relative frame of reference for the flow.')
-
-            # Remove from mapped.
-            self._mapped_atom_indices = self._mapped_atom_indices[self._mapped_atom_indices != self._origin_atom_idx]
-
-            # Insert in conditioning maintaining the order.
-            if self._conditioning_atom_indices is None:
-                self._conditioning_atom_indices = self._origin_atom_idx.unsqueeze(0).clone()
-            else:
-                insert_idx = torch.searchsorted(self._conditioning_atom_indices, self._origin_atom_idx)
-                self._conditioning_atom_indices = torch.concatenate([
-                    self._conditioning_atom_indices[:insert_idx],
-                    self._origin_atom_idx.unsqueeze(0),
-                    self._conditioning_atom_indices[insert_idx:],
-                ])
-
-            # Remove also from the set in place.
-            mapped_atom_indices_w_fixed_set.remove(origin_atom_idx)
-
     def _analyze_dataset(
             self,
-            z_matrix: np.ndarray,
+            z_matrix: Sequence[Sequence[int]],
             cartesian_to_mixed_flow: torch.nn.Module,
     ) -> Tuple[torch.Tensor]:
         """Check the Z-matrix robustness and compute the minimum and maximum value of each DOF in the trajectory.
@@ -643,8 +626,9 @@ class MixedMAFMap(TFEPMapBase):
         and to compute the min/max values of the DOFs.
 
         The returned min/max values are for the coordinates in the relative
-        frame of reference. This is useful to calculate appropriate values for
-        the left/rightmost nodes of the neural spline transformer.
+        frame of reference. This is useful to calculate appropriate initial
+        values for the left/rightmost nodes of the neural spline transformer
+        (e.g., for Cartesian coordinates).
 
         For this, we need to calculate the minimum and maximum dof AFTER it has
         gone through the partial flow removing the fixed atoms and the relative
@@ -653,9 +637,10 @@ class MixedMAFMap(TFEPMapBase):
 
         Parameters
         ----------
-        z_matrix: np.ndarray
-            The Z-matrix. The atom indices must refer to those after the fixed
-            atoms have been removed.
+        z_matrix : Sequence[Sequence[int]]
+            The Z-matrix in the same format passed to _CartesianToMixedFlow.
+            Atom indices must refer to those after the fixed atoms have been
+            removed.
         cartesian_to_mixed_flow : torch.nn.Module
             The flow used to convert Cartesian into mixed coordinates.
 
@@ -671,9 +656,6 @@ class MixedMAFMap(TFEPMapBase):
         """
         # This is needed to check for collinearity of the reference atoms.
         ref_atoms = self.get_reference_atoms_indices(remove_fixed=True)
-        # We don't need to check collinearity if only the origin or the axes atoms are given.
-        if (ref_atoms is not None) and (len(ref_atoms) < 3):
-            ref_atoms = None
 
         # We temporarily set the flow to the partial flow to process the positions.
         assert self._flow is None
@@ -703,11 +685,11 @@ class MixedMAFMap(TFEPMapBase):
                     raise RuntimeError(f'Row {row_idx+1} have collinear atoms.')
 
             # Test collinearity reference frame atoms.
-            if ref_atoms is not None and is_collinear(batch_atom_positions[:, ref_atoms]):
+            if is_collinear(batch_atom_positions[:, ref_atoms]):
                 raise RuntimeError('Axes atoms are collinear!')
 
             # Go through the coordinate conversion flow.
-            dofs = cartesian_to_mixed_flow._cartesian_to_mixed(batch_positions)[0]
+            dofs = cartesian_to_mixed_flow.cartesian_to_mixed(batch_positions)[0]
 
             # Take the min/max across the batch of the selected DOFs.
             batch_min = torch.min(dofs, dim=0).values
@@ -731,9 +713,7 @@ class MixedMAFMap(TFEPMapBase):
             cartesian_to_mixed_flow: torch.nn.Module,
             min_dof_vals: torch.Tensor,
             max_dof_vals: torch.Tensor,
-            maf_conditioning_dof_indices: Optional[torch.Tensor],
-            maf_valence_angles_dof_indices: torch.Tensor,
-            maf_torsions_dof_indices: torch.Tensor,
+            dof_indices: dict[str, Optional[torch.Tensor]],
     ) -> torch.nn.Module:
         """Return the transformer for the MAF.
 
@@ -745,15 +725,9 @@ class MixedMAFMap(TFEPMapBase):
             Minimum values observed in the trajectory for the DOFs in mixed coordinates.
         max_dof_vals : torch.Tensor
             Maximum values observed in the trajectory for the DOFs in mixed coordinates.
-        maf_conditioning_dof_indices : torch.Tensor or None
-            The indices of the conditioning DOFs after the conversion to mixed
-            coordinates.
-        maf_valence_angles_dof_indices : torch.Tensor
-            The indices of valence bond angles (which are defined in [0, pi]
-            and not periodic) after the conversion to mixed coordinates.
-        maf_torsions_dof_indices : torch.Tensor
-            The indices of the torsion angles (which are defined in [0, 2pi]
-            and periodic) after the conversion to mixed coordinates.
+        dof_indices : dict[str, Optional[torch.Tensor]]
+            The indices of the DOFs after the conversion to mixed coordinates
+            ``_CartesianToMixedFlow.get_dof_indices_by_type()``.
 
         """
         # We need to determine the limits only for the mapped (not conditioning)
@@ -764,98 +738,139 @@ class MixedMAFMap(TFEPMapBase):
         x0 = min_dof_vals
         xf = max_dof_vals
 
-        # Set the limits for the bonds and the two distances of the axes atoms
-        # from the origin (which might not be bonds).
-        distances_dof_indices = cartesian_to_mixed_flow.get_maf_distance_dof_indices()
-        x0[distances_dof_indices] = torch.max(
+        # Set the limits for the bonds.
+        x0[dof_indices['distances']] = torch.max(
             torch.tensor(0.0),
-            x0[distances_dof_indices] - self.hparams.distance_lower_limit_displacement,
+            x0[dof_indices['distances']] - self.hparams.distance_lower_limit_displacement,
         )
 
         # Now filter all conditioning dofs.
-        if maf_conditioning_dof_indices is not None:
-            mask = torch.isin(torch.arange(self.n_nonfixed_dofs), maf_conditioning_dof_indices,
-                              assume_unique=True, invert=True)
+        if dof_indices['conditioning'] is not None:
+            mask = torch.isin(torch.arange(cartesian_to_mixed_flow.n_dofs_out),
+                              dof_indices['conditioning'], assume_unique=True, invert=True)
             x0 = x0[mask]
             xf = xf[mask]
 
-            # We need to remove (and shift) the conditioning DOF also from distance/angle indices.
-            distances_dof_indices = remove_and_shift_sorted_indices(
-                distances_dof_indices, removed_indices=maf_conditioning_dof_indices)
-            maf_torsions_dof_indices = remove_and_shift_sorted_indices(
-                maf_torsions_dof_indices, removed_indices=maf_conditioning_dof_indices)
-            maf_valence_angles_dof_indices = remove_and_shift_sorted_indices(
-                maf_valence_angles_dof_indices, removed_indices=maf_conditioning_dof_indices)
+            # We need to remove (and shift) the conditioning DOF from the type
+            # indices. Copy to avoid modifying the input argument.
+            dof_indices = dof_indices.copy()
+            for idx_type in ['distances', 'angles', 'torsions', 'cartesians', 'reference']:
+                dof_indices[idx_type] = remove_and_shift_sorted_indices(
+                    dof_indices[idx_type], removed_indices=dof_indices['conditioning'])
 
-        # Cartesian DOFs indices are what is left.
-        all_other_indices = set(
-            distances_dof_indices.tolist() +
-            maf_valence_angles_dof_indices.tolist() +
-            maf_torsions_dof_indices.tolist()
-        )
-        cartesian_dof_indices = torch.tensor(
-            [i for i in range(len(x0)) if i not in all_other_indices]).to(distances_dof_indices)
+        # Initialize the transformers. We set the limits of angles from 0 to 1
+        # since they are normalized. Only torsions are periodic since valence
+        # bond angles are [0, pi].
+        assert cartesian_to_mixed_flow.rel_ic.normalize_angles
+        transformer_indices = [
+            dof_indices['distances'],
+            dof_indices['angles'],
+            dof_indices['torsions'],
+        ]
+        transformers = [
+            tfep.nn.transformers.NeuralSplineTransformer(
+                x0=x0[dof_indices['distances']].detach(),
+                xf=xf[dof_indices['distances']].detach(),
+                n_bins=5,
+                circular=False,
+                identity_boundary_slopes=True,
+                learn_lower_bound=False,
+                learn_upper_bound=True,
+            ),
+            tfep.nn.transformers.NeuralSplineTransformer(
+                x0=torch.zeros(len(dof_indices['angles'])),
+                xf=torch.ones(len(dof_indices['angles'])),
+                n_bins=5,
+                circular=False,
+                identity_boundary_slopes=False,
+                learn_lower_bound=False,
+                learn_upper_bound=False,
+            ),
+            tfep.nn.transformers.NeuralSplineTransformer(
+                x0=torch.zeros(len(dof_indices['torsions'])),
+                xf=torch.ones(len(dof_indices['torsions'])),
+                n_bins=5,
+                circular=True,
+                identity_boundary_slopes=False,
+                learn_lower_bound=False,
+                learn_upper_bound=False,
+            ),
+        ]
 
-        # Initialize the splines.
-        distance_spline = tfep.nn.transformers.NeuralSplineTransformer(
-            x0=x0[distances_dof_indices].detach(),
-            xf=xf[distances_dof_indices].detach(),
-            n_bins=5,
-            circular=False,
-            identity_boundary_slopes=True,
-            learn_lower_bound=False,
-            learn_upper_bound=True,
-        )
-        cartesian_spline = tfep.nn.transformers.NeuralSplineTransformer(
-            x0=x0[cartesian_dof_indices].detach(),
-            xf=xf[cartesian_dof_indices].detach(),
-            n_bins=5,
-            circular=False,
-            identity_boundary_slopes=True,
-            learn_lower_bound=True,
-            learn_upper_bound=True,
-        )
+        # If there is only 1 fragment and rototranslational DOFs are removed
+        # there are no Cartesian coordinates.
+        if len(dof_indices['cartesians']) > 0:
+            transformers.append(tfep.nn.transformers.NeuralSplineTransformer(
+                x0=x0[dof_indices['cartesians']].detach(),
+                xf=xf[dof_indices['cartesians']].detach(),
+                n_bins=5,
+                circular=False,
+                identity_boundary_slopes=True,
+                learn_lower_bound=True,
+                learn_upper_bound=True,
+            ))
+            transformer_indices.append(dof_indices['cartesians'])
 
-        # We set the limits of angles from 0 to 1 since they are normalized.
-        # Only torsions are periodic since valence bond angles are [0, pi].
-        assert cartesian_to_mixed_flow._rel_ic.normalize_angles
-        angle_spline = tfep.nn.transformers.NeuralSplineTransformer(
-            x0=torch.zeros(len(maf_valence_angles_dof_indices)),
-            xf=torch.ones(len(maf_valence_angles_dof_indices)),
-            n_bins=5,
-            circular=False,
-            identity_boundary_slopes=False,
-            learn_lower_bound=False,
-            learn_upper_bound=False,
-        )
-        torsion_spline = tfep.nn.transformers.NeuralSplineTransformer(
-            x0=torch.zeros(len(maf_torsions_dof_indices)),
-            xf=torch.ones(len(maf_torsions_dof_indices)),
-            n_bins=5,
-            circular=True,
-            identity_boundary_slopes=False,
-            learn_lower_bound=False,
-            learn_upper_bound=False,
-        )
+        # If rototranslational DOFs are removed, this is empty.
+        if len(dof_indices['reference']) > 0:
+            # The rototranslational DOFs are always 0. When this happen, a neural
+            # spline can learn an identity function with an arbitrary Jacobian
+            # adding a spurious contribution so we use a volume-preserving shift
+            # transformer.
+            transformers.append(tfep.nn.transformers.VolumePreservingShiftTransformer())
+            transformer_indices.append(dof_indices['reference'])
 
         return tfep.nn.transformers.MixedTransformer(
-            transformers=[
-                distance_spline,
-                angle_spline,
-                torsion_spline,
-                cartesian_spline,
-            ],
-            indices=[
-                distances_dof_indices,
-                maf_valence_angles_dof_indices,
-                maf_torsions_dof_indices,
-                cartesian_dof_indices,
-            ],
+            transformers=transformers,
+            indices=transformer_indices,
         )
+
+    def _get_maf_degrees_in(self, n_dofs_in, maf_dof_indices):
+        """Assign degrees to each input DOFs.
+
+        Returns a pair [degrees_in_ascending, degrees_in_descending] input
+        arguments for MAF in the ascending and descending order.
+
+        The rototranslational DOFs (if not removed) are always assigned the
+        last degree, both in ascending and descending order, since they are
+        constant.
+
+        """
+        # If we don't remove translation/rotation, we assign their degree later.
+        # To make this work with generate_degrees() we set them as conditioning
+        # which makes it temporarily assign a -1 degree to them.
+        if len(maf_dof_indices['reference']) > 0:
+            # Avoid modifying the original maf_dof_indices variable.
+            maf_dof_indices = maf_dof_indices.copy()
+            if maf_dof_indices['conditioning'] is None:
+                maf_dof_indices['conditioning'] = torch.tensor([]).to(maf_dof_indices['reference'])
+
+            # We always remove translation/rotation when reference atoms are
+            # conditioning so these are not repeated indices.
+            maf_dof_indices['conditioning'] = torch.cat([
+                maf_dof_indices['conditioning'],
+                maf_dof_indices['reference'],
+            ])
+
+        # Create the degrees for the ascending and descending order.
+        degrees_in = []
+        for order in ['ascending', 'descending']:
+            degrees_in.append(tfep.nn.conditioners.made.generate_degrees(
+                n_features=n_dofs_in,
+                order=order,
+                conditioning_indices=maf_dof_indices['conditioning'],
+            ))
+
+        # Now add the degree of the reference.
+        last_degree = torch.max(degrees_in[0]) + 1
+        for degrees in degrees_in:
+            degrees[maf_dof_indices['reference']] = last_degree
+
+        return degrees_in
 
 
 # =============================================================================
-# HELPER CLASSES AND FUNCTIONS
+# HELPER CLASSES AND FUNCTIONS TO CONSTRUCT THE Z-MATRIX
 # =============================================================================
 
 def check_independent(z_matrix):
@@ -932,46 +947,54 @@ def _is_hydrogen(atom):
     return element == 'H'
 
 
-# TODO: MOVE TO tfep.nn.flows?
-class _CartesianToMixedFlow(torch.nn.Module):
-    """Utility flow to convert from Cartesian to mixed Cartesian/internal coordinates.
+# =============================================================================
+# COORDINATE CONVERSION
+# =============================================================================
 
-    This also sets the relative frame of reference if origin/axes_atoms_indices are passed.
+class _CartesianToMixedFlow(torch.nn.Module):
+    """Flow converting Cartesian to mixed (internal+Cartesian) coordinates.
+
+    This class 1) converts Cartesian coordinates to mixed coordinates, 2)
+    executes the wrapped flow, and 3) converts the coordinates back from mixed
+    to Cartesian.
+
+    While converting to mixed coordinates, the flow roto-translates the Cartesian
+    coordinates to a relative frame of reference defined by the origin and axes
+    atoms. Optionally, these roto-translational degrees of freedom can be removed
+    (e.g., if the mapped system has roto-translational symmetry).
 
     """
 
     def __init__(
             self,
             flow: torch.nn.Module,
-            cartesian_atom_indices: np.ndarray,
-            z_matrix: np.ndarray,
-            origin_atom_idx: Optional[torch.Tensor],
-            axes_atoms_indices: Optional[torch.Tensor],
+            cartesian_atom_indices: Sequence[int],
+            z_matrix: Sequence[Sequence[int]],
+            reference_atom_indices: torch.Tensor,
+            remove_ref_rototranslation: Sequence[bool],
     ):
         """Constructor.
-
-        All the indices must be after the fixed atoms have been removed.
 
         Parameters
         ----------
         flow : torch.nn.Module
-            The normalizing flow to wrap that takes as input mixed coordinates.
-        cartesian_atom_indices : np.ndarray
+            The wrapped normalizing flow that takes as input the mixed
+            coordinates.
+        cartesian_atom_indices : Sequence[int]
             Shape ``(n_cartesian_atoms,)``. Indices of the atoms represented as
-            Cartesian (both mapped and conditioning) after the fixed atoms have
-            been removed. This must be an ordered array.
+            Cartesian (both mapped and conditioning, and  after the fixed atoms
+            have been removed. The indices must be ordered.
         z_matrix : np.ndarray
             Shape ``(n_ic_atoms, 4)``. The Z-matrix for the atoms represented as
             internal coordinates.
-        origin_atom_idx : torch.Tensor or None
-            The index of the origin atom after the fixed atoms are removed. If
-            given, the Cartesian coordinates will be translated to have this
-            atom in the origin before being passed to the MAF.
-        axes_atoms_indices : torch.Tensor or None
-            The indices of the axes atoms determining the orientation of the
-            reference frame after the fixed atoms are removed. If passed, the
-            Cartesian coordinates will be rotated into this reference frame
-            before being passed to the MAF.
+        reference_atom_indices : torch.Tensor
+            The indices (after the fixed atoms are removed) of the origin, axis,
+            and plane atoms (in this order) used to determine the relative
+            frame of reference for the Cartesian coordinates.
+        remove_ref_rototranslation : Sequence[bool]
+            Shape (3,). Whether to remove the rototranslational degrees of
+            freedom of the 3 reference atoms from the coordinates passed to the
+            wrapped flow.
 
         """
         from bgflow.nn.flow.crd_transform.ic import RelativeInternalCoordinateTransformation
@@ -980,169 +1003,157 @@ class _CartesianToMixedFlow(torch.nn.Module):
 
         #: Wrapped flow.
         self.flow = flow
+        self.register_buffer('remove_ref_rototranslation', torch.tensor(remove_ref_rototranslation))
+
+        # Turn to tensor.
+        z_matrix = ensure_tensor_sequence(z_matrix)
+        cartesian_atom_indices = ensure_tensor_sequence(cartesian_atom_indices)
+        reference_atom_indices = ensure_tensor_sequence(reference_atom_indices)
+
+        # Move reference frame atoms at the end to simplify book-keeping.
+        # Reference frame atoms are always Cartesian so we can use searchsorted.
+        cartesian_atom_indices = remove_and_shift_sorted_indices(
+            cartesian_atom_indices,
+            removed_indices=reference_atom_indices.sort().values,
+            remove=True,
+            shift=False,
+        )
+        cartesian_atom_indices = torch.cat([cartesian_atom_indices, reference_atom_indices])
 
         # The modules performing the coordinate conversion.
-        self._rel_ic = RelativeInternalCoordinateTransformation(
+        self.rel_ic = RelativeInternalCoordinateTransformation(
             z_matrix=z_matrix,
             fixed_atoms=cartesian_atom_indices,
             normalize_angles=True,
         )
 
-        # Find the indices of the reference atoms in the cartesian tensor after
-        # cartesian_to_mixed() is called.
-        reference_atoms_indices_in_cartesian = []
-
-        # Reference atoms (if present) are always in cartesian_atom_indices so we can use searchsorted.
-        if origin_atom_idx is not None:
-            idx = np.searchsorted(cartesian_atom_indices, [origin_atom_idx.tolist()])
-            reference_atoms_indices_in_cartesian.append(idx[0])
-        if axes_atoms_indices is not None:
-            indices = np.searchsorted(cartesian_atom_indices, axes_atoms_indices.tolist())
-            reference_atoms_indices_in_cartesian.extend(indices)
-
-        # Convert to tensor.
-        self.register_buffer('_reference_atoms_indices_in_cartesian',
-                             torch.tensor(reference_atoms_indices_in_cartesian, dtype=int))
-
     @property
-    def has_origin_atom(self) -> bool:
-        """True if there is an origin atom for the relative frame of reference."""
-        return len(self._reference_atoms_indices_in_cartesian) in {1, 3}
-
-    @property
-    def has_axes_atoms(self) -> bool:
-        """True if there are axes atoms for the relative frame of reference."""
-        return len(self._reference_atoms_indices_in_cartesian) > 1
-
-    @property
-    def cartesian_atom_indices(self) -> Optional[np.ndarray]:
+    def cartesian_atom_indices(self) -> torch.Tensor:
         """The atom indices of the atoms treated in Cartesian coordinates."""
-        return self._rel_ic.fixed_atoms
+        return self.rel_ic.fixed_atoms
 
     @property
-    def z_matrix(self) -> np.ndarray:
-        """The Z-matrix."""
-        return self._rel_ic.z_matrix
+    def z_matrix(self) -> torch.Tensor:
+        """torch.Tensor: The Z-matrix."""
+        return self.rel_ic.z_matrix
 
     @property
     def n_ic_atoms(self) -> int:
-        """Number of atoms represented in internal coordinates."""
+        """int: Total number of atoms represented in internal coordinates (excluding reference atoms)."""
         return len(self.z_matrix)
 
-    def get_maf_conditioning_dof_indices(self, conditioning_atom_indices: Optional[torch.Tensor]) -> torch.Tensor:
-        """Return the indices of the conditioning DOFs after going through _CartesianToMixedFlow.
+    @property
+    def n_dofs_out(self) -> int:
+        """int: Number of degrees of freedom after the conversion to mixed coordinates."""
+        return self._get_coords_indices_by_type()[-1].tolist()
+
+    def _get_coords_indices_by_type(self):
+        """The first index in the mixed coordinates for each type of coordinate."""
+        # Cartesian atoms include also the 6 rototranslational DOFs.
+        n_cartesians = 3 * len(self.cartesian_atom_indices) - 3
+        if self.remove_ref_rototranslation[0]:
+            n_cartesians -= 3
+        if self.remove_ref_rototranslation[1]:
+            n_cartesians -= 2
+        if self.remove_ref_rototranslation[2]:
+            n_cartesians -= 1
+
+        # Mixed coordinates are obtained by concatenating coord types in this order:
+        coords_sizes = [
+            self.n_ic_atoms,  # bonds
+            self.n_ic_atoms,  # angles
+            self.n_ic_atoms,  # torsions
+            1,  # d01
+            1,  # d02
+            1,  # a102
+            n_cartesians, # cartesian (including rototranslational)
+        ]
+        return torch.cumsum(torch.tensor(coords_sizes), dim=0)
+
+    def get_dof_indices_by_type(
+            self,
+            conditioning_atom_indices: Optional[torch.Tensor] = None,
+    ) -> dict[str, torch.Tensor]:
+        """Return the indices of the different types of DOFs after conversion to mixed coordinates.
 
         Parameters
         ----------
         conditioning_atom_indices : torch.Tensor or None
-            Shape (n_atoms,). The indices of the conditioning atoms (including
-            the reference atoms) after the fixed atoms have been removed.
+            Shape (n_atoms,). The indices of the conditioning atoms (after the
+            fixed atoms have been removed).
 
         Returns
         -------
-        maf_conditioning_dof_indices : torch.Tensor or None
-            The DOF indices after going through _CartesianToMixedFlow.
+        indices_by_type : dict[str, torch.Tensor]
+            A dict of indices grouped by type of DOF with keys: 'distances',
+            'angles', 'torsions', 'cartesians', 'conditioning', and 'reference'
+            (non-empty only if ``(~remove_ref_rototranslation).any()`` is
+            ``True``). Note that the indices in 'conditioning' and the other
+            types will overlap (i.e., both mapped and conditioning DOF indices
+            are included in 'distances', 'angles', etc.).
 
         """
-        # If there are no conditioning atoms or if the only conditioning atom is
-        # the origin atom, return None. The origin atom has no unconstrained DOFs
-        # and it is removed by _CartesianToMixedFlow.
-        if ((conditioning_atom_indices is None) or
-                (len(conditioning_atom_indices) == 0) or
-                (len(conditioning_atom_indices) == 1 and self.has_origin_atom)):
-            return None
+        coords_indices = self._get_coords_indices_by_type()
+        indices_by_type = {
+            'distances': torch.arange(coords_indices[0]),
+            'angles': torch.arange(coords_indices[0], coords_indices[1]),
+            'torsions': torch.arange(coords_indices[1], coords_indices[2]),
+            'd01': torch.arange(coords_indices[2], coords_indices[3]),
+            'd02': torch.arange(coords_indices[3], coords_indices[4]),
+            'a102': torch.arange(coords_indices[4], coords_indices[5]),
+            'cartesians': torch.arange(coords_indices[5], coords_indices[6]),
+        }
 
-        # Convert the conditioning atom indices to their respective index in cartesian_atom_indices.
-        conditioning_atom_indices_set = set(conditioning_atom_indices.tolist())
-        conditioning_atom_indices_in_cartesian = [i for i, v in enumerate(self.cartesian_atom_indices)
-                                                  if v in conditioning_atom_indices_set]
+        # Distances and angles must include also the reference frame atom IC coords.
+        indices_by_type['distances'] = torch.cat([indices_by_type['distances'],
+                                                  indices_by_type['d01'],
+                                                  indices_by_type['d02']])
+        indices_by_type['angles'] = torch.cat([indices_by_type['angles'],
+                                               indices_by_type['a102']])
 
-        # We need to treat reference atoms specially because _cartesian_to_mixed()
-        # removes them from the cartesian atoms and places the unconstrained DOFs
-        # of the axes atoms between the internal and the Cartesian coordinates.
-        reference_atoms_indices_in_cartesian_set = set(self._reference_atoms_indices_in_cartesian.tolist())
-        conditioning_atom_indices_in_cartesian_no_ref = [i for i in conditioning_atom_indices_in_cartesian
-                                                         if i not in reference_atoms_indices_in_cartesian_set]
-        conditioning_atom_indices_in_cartesian_no_ref = torch.tensor(
-            conditioning_atom_indices_in_cartesian_no_ref).to(self._reference_atoms_indices_in_cartesian)
+        # Rototranslational degrees of freedom, if not removed, are always 0.0
+        # and must be treated specially by the flow. These are at the end of cartesians.
+        n_refs_in_cartesians = 0
+        if not self.remove_ref_rototranslation[0]:
+            n_refs_in_cartesians += 3
+        if not self.remove_ref_rototranslation[1]:
+            n_refs_in_cartesians += 2
+        if not self.remove_ref_rototranslation[2]:
+            n_refs_in_cartesians += 1
 
-        # Shift indices due to the removed reference atoms. We eventually will
-        # shift the indices to the right for the axes atoms DOFs later.
-        reference_atoms_indices_in_cartesian_sorted = self._reference_atoms_indices_in_cartesian.sort()[0]
-        conditioning_atom_indices_in_cartesian_no_ref = remove_and_shift_sorted_indices(
-            conditioning_atom_indices_in_cartesian_no_ref,
-            removed_indices=reference_atoms_indices_in_cartesian_sorted,
-            remove=False,
-        )
+        if n_refs_in_cartesians > 0:
+            indices_by_type['reference'] = indices_by_type['cartesians'][-n_refs_in_cartesians:]
+            indices_by_type['cartesians'] = indices_by_type['cartesians'][:-n_refs_in_cartesians]
+        else:
+            indices_by_type['reference'] = torch.tensor([]).to(indices_by_type['cartesians'])
 
-        # Shift indices by the number of internal coordinates before the Cartesian ones.
-        maf_conditioning_dof_indices = conditioning_atom_indices_in_cartesian_no_ref + self.n_ic_atoms
+        # Check if there are no conditioning atoms.
+        if conditioning_atom_indices is None:
+            indices_by_type['conditioning'] = None
+        else:
+            conditioning_atom_indices_set = set(conditioning_atom_indices.tolist())
 
-        # Convert from atom to DOF indices.
-        maf_conditioning_dof_indices = atom_to_flattened_indices(maf_conditioning_dof_indices)
+            # Conditioning atoms are always Cartesian. Find their DOF indices
+            # in indices_by_type['cartesians'] (excluding reference atoms).
+            indices = [i for i, v in enumerate(self.cartesian_atom_indices[:-3].tolist())
+                       if v in conditioning_atom_indices_set]
+            indices = atom_to_flattened_indices(torch.tensor(indices).to(indices_by_type['cartesians']))
+            cond_dof_indices = indices_by_type['cartesians'][indices]
 
-        # Axes atoms can be either mapped or conditioning. The DOFs of the axes
-        # atoms are placed between the internal coordinates and the Cartesian atoms.
-        if self.has_axes_atoms:
-            # Whether the axes atoms are mapped or not, they have three degrees of
-            # freedom that shift to the right the conditioning DOF indices.
-            maf_conditioning_dof_indices = maf_conditioning_dof_indices + 3
+            # Rototranslational DOFs of conditioning reference atoms are always
+            # removed so we need to check only their internal coords.
+            cond_dof_indices = [cond_dof_indices]
+            axis_atom_idx, plane_atom_idx = self.cartesian_atom_indices[-2:].tolist()
+            if axis_atom_idx in conditioning_atom_indices_set:
+                cond_dof_indices.append(indices_by_type['d01'])
+            if plane_atom_idx in conditioning_atom_indices_set:
+                cond_dof_indices.extend([indices_by_type['d02'], indices_by_type['a102']])
+            indices_by_type['conditioning'] = torch.cat(cond_dof_indices).sort().values
 
-            # We need to know whether the axes atoms are conditioning.
-            conditioning_atom_indices_in_cartesian_set = set(conditioning_atom_indices_in_cartesian)
-            axes_atoms_indices_in_cartesian = self._reference_atoms_indices_in_cartesian[-2:].tolist()
+            if len(indices_by_type['conditioning']) == 0:
+                indices_by_type['conditioning'] = None
 
-            # Collect the axes atoms DOFs that are conditioning.
-            to_concatenate = []
-            if axes_atoms_indices_in_cartesian[0] in conditioning_atom_indices_in_cartesian_set:
-                to_concatenate.append(3*self.n_ic_atoms)
-            if axes_atoms_indices_in_cartesian[1] in conditioning_atom_indices_in_cartesian_set:
-                to_concatenate.extend([3*self.n_ic_atoms+1, 3*self.n_ic_atoms+2])
-
-            # Concatenate reference and other conditioning DOFs.
-            if len(to_concatenate) > 0:
-                to_concatenate = torch.tensor(to_concatenate).to(maf_conditioning_dof_indices)
-                maf_conditioning_dof_indices = torch.cat([to_concatenate, maf_conditioning_dof_indices])
-
-        return maf_conditioning_dof_indices
-
-    def get_maf_angles_dof_indices(self) -> Tuple[torch.Tensor]:
-        """
-        Return the indices of all angles (i.e., valence bond angles and torsions)
-        passed to the MAF after the conversion from Cartesian to mixed.
-        """
-        # Except for the single angle defining the reference frame atoms, all
-        # angles and torsions are placed right after the bonds.
-        maf_valence_angles_dof_indices = list(range(self.n_ic_atoms, 2*self.n_ic_atoms))
-        # Check if there are axes atoms, whose DOFs are placed between the
-        # internal and Cartesian coordinates after the conversion.
-        if self.has_axes_atoms:
-            # The axes atoms are defined by two distances and 1 angle.
-            maf_valence_angles_dof_indices.append(3*self.n_ic_atoms+2)
-
-        # Return also valence bond and torsion angles.
-        maf_valence_angles_dof_indices = torch.tensor(maf_valence_angles_dof_indices)
-        maf_torsions_dof_indices = torch.arange(2*self.n_ic_atoms, 3*self.n_ic_atoms)
-
-        return maf_valence_angles_dof_indices, maf_torsions_dof_indices
-
-    def get_maf_distance_dof_indices(self) -> torch.Tensor:
-        """Return the indices of the bond DOFs after the conversion from Cartesian to mixed.
-
-        These include both bonds and the two distances of the axes atoms from
-        the origin.
-
-        """
-        # The bonds are placed at the beginning.
-        maf_distance_dof_indices = list(range(self.n_ic_atoms))
-
-        # Check if there are axes atoms, whose DOFs are placed between the
-        # internal and Cartesian coordinates after the conversion.
-        if self.has_axes_atoms:
-            # The axes atoms are defined by two distances and 1 angle.
-            maf_distance_dof_indices.extend([3*self.n_ic_atoms, 3*self.n_ic_atoms+1])
-
-        return torch.tensor(maf_distance_dof_indices)
+        return indices_by_type
 
     def forward(self, x):
         return self._pass(x, inverse=False)
@@ -1152,7 +1163,7 @@ class _CartesianToMixedFlow(torch.nn.Module):
 
     def _pass(self, x, inverse):
         # Convert from Cartesian to mixed coordinates.
-        y, cumulative_log_det_J, origin_atom_position, rotation_matrix = self._cartesian_to_mixed(x)
+        y, cumulative_log_det_J, origin_atom_position, rotation_matrix = self.cartesian_to_mixed(x)
 
         # Run flow.
         if inverse:
@@ -1162,15 +1173,42 @@ class _CartesianToMixedFlow(torch.nn.Module):
         cumulative_log_det_J = cumulative_log_det_J + log_det_J
 
         # Convert from mixed to Cartesian coordinates.
-        y, log_det_J = self._mixed_to_cartesian(y, origin_atom_position, rotation_matrix)
+        y, log_det_J = self.mixed_to_cartesian(y, origin_atom_position, rotation_matrix)
         cumulative_log_det_J = cumulative_log_det_J + log_det_J
 
         return y, cumulative_log_det_J
 
-    def _cartesian_to_mixed(self, x: torch.Tensor) -> Tuple[torch.Tensor]:
-        """Convert from Cartesian to mixed coordinates."""
+    def cartesian_to_mixed(self, x: torch.Tensor) -> Tuple[torch.Tensor]:
+        """Convert from Cartesian to mixed coordinates.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape ``(batch_size, n_atoms*3)`` or ``(batch_size, n_atoms, 3)``.
+            The Cartesian coordinates.
+
+        Returns
+        -------
+        y : torch.Tensor
+            Shape ``(batch_size, n_atoms*3 - fixed_dofs)`` where ``fixed_dof``
+            can be 0, 3, or 6 depending on the value of ``self.remove_ref_rototranslation``
+            The mixed coordinates.
+        log_det_J : torch.Tensor
+            Shape ``(batch_size,)``. The logarithm of the absolute Jacobian
+            determinant of the coordinate transformation.
+        origin_atom_position : torch.Tensor
+            Shape ``(batch_size, 1, 3)``. The position of the origin of the
+            relative frame of reference in the original coordinate system.
+        rotation_matrix : torch.Tensor
+            Shape ``(batch_size, 1, 4)``. A rotation matrix representing the
+            rotation performed to transform the original coordinate system into
+            the relative one.
+
+        """
+        from bgflow.nn.flow.crd_transform.ic import normalize_torsions
+
         # Convert to mixed coordinates.
-        bonds, angles, torsions, x_cartesian, cumulative_log_det_J = self._rel_ic(x)
+        bonds, angles, torsions, x_cartesian, cumulative_log_det_J = self.rel_ic(x)
 
         # From (batch, 1) to (batch,).
         cumulative_log_det_J = cumulative_log_det_J.squeeze(-1)
@@ -1179,165 +1217,165 @@ class _CartesianToMixedFlow(torch.nn.Module):
         x_cartesian = flattened_to_atom(x_cartesian)
         batch_size, n_cartesian_atoms, _ = x_cartesian.shape
 
-        # We'll have to remove the reference atoms from the cartesian atoms using a mask.
-        if self.has_origin_atom or self.has_axes_atoms:
-            kept_atoms_mask = torch.full((n_cartesian_atoms,), True).to(
-                self._reference_atoms_indices_in_cartesian.device)
-
         # Center the Cartesian coordinates on the origin atom.
-        if not self.has_origin_atom:
-            origin_atom_position = None
-        else:
-            # Flag origin atom to be removed.
-            origin_atom_idx = self._reference_atoms_indices_in_cartesian[0]
-            kept_atoms_mask[origin_atom_idx] = False
+        origin_atom_idx, axis_atom_idx, plane_atom_idx = -3, -2, -1
+        origin_atom_position = x_cartesian[:, origin_atom_idx]
+        x_cartesian = x_cartesian - origin_atom_position.unsqueeze(1)
 
-            # Save the position to restore it later.
-            origin_atom_position = x_cartesian[:, origin_atom_idx]
-            x_cartesian = x_cartesian - origin_atom_position.unsqueeze(1)
+        # Find rotation matrix to re-orient the frame of reference.
+        rotation_matrix = reference_frame_rotation_matrix(
+            axis_atom_positions=x_cartesian[:, axis_atom_idx],
+            plane_atom_positions=x_cartesian[:, plane_atom_idx],
+            axis=get_axis_from_name('x').to(x_cartesian),
+            plane_axis=get_axis_from_name('y').to(x_cartesian),
+            # We can project on positive axis since the neural spline
+            # never makes the coordinate negative.
+            project_on_positive_axis=True,
+        )
 
-        # Re-orient the frame of reference.
-        if not self.has_axes_atoms:
-            rotation_matrix = None
-            axes_atoms_dof = [torch.empty(0).to(self._reference_atoms_indices_in_cartesian)]
-        else:
-            axis_atom_idx = self._reference_atoms_indices_in_cartesian[-2]
-            plane_atom_idx = self._reference_atoms_indices_in_cartesian[-1]
-            axis_atom_pos = x_cartesian[:, axis_atom_idx]
-            plane_atom_pos = x_cartesian[:, plane_atom_idx]
+        # Rotate all Cartesian coordinates.
+        x_cartesian = batchwise_rotate(x_cartesian, rotation_matrix)
 
-            # Find rotation matrix.
-            rotation_matrix = reference_frame_rotation_matrix(
-                axis_atom_positions=axis_atom_pos,
-                plane_atom_positions=plane_atom_pos,
-                axis=get_axis_from_name('x').to(x_cartesian),
-                plane_axis=get_axis_from_name('y').to(x_cartesian),
-                # We can project on positive axis since the neural spline
-                # never makes the coordinate negative.
-                project_on_positive_axis=True,
-            )
+        # The (positive) x-coordinate of the axis atom is the distance from the origin.
+        d01 = x_cartesian[:, axis_atom_idx, 0]
 
-            # Rotate all Cartesian coordinates.
-            x_cartesian = batchwise_rotate(x_cartesian, rotation_matrix)
+        # Transform the coordinates on the x-y plane to polar (distance, angle) from the origin.
+        d02, a102, log_det_J = cartesian_to_polar(
+            x_cartesian[:, plane_atom_idx, 0],
+            x_cartesian[:, plane_atom_idx, 1],
+            return_log_det_J=True
+        )
+        cumulative_log_det_J = cumulative_log_det_J + log_det_J
 
-            # The (positive) x-coordinate of the axis atom is the distance from the origin.
-            dist_axis_atom = x_cartesian[:, axis_atom_idx, 0]
-
-            # Transform the coordinates on the x-y plane to polar (distance, angle) from the origin.
-            dist_plane_atom, angle, log_det_J = cartesian_to_polar(
-                x_cartesian[:, plane_atom_idx, 0],
-                x_cartesian[:, plane_atom_idx, 1],
-                return_log_det_J=True
-            )
-            cumulative_log_det_J = cumulative_log_det_J + log_det_J
-
-            # Normalize the angle. angle is in [-pi, pi] so we use normalize_torsions().
-            # Normalize torsion takes and return shape (batch_size, 1), not (batch_size,).
-            from bgflow.nn.flow.crd_transform.ic import normalize_torsions
-            angle, log_det_J = normalize_torsions(angle.unsqueeze(-1))
-            angle = angle.squeeze(-1)
-            cumulative_log_det_J = cumulative_log_det_J + log_det_J.squeeze(-1)
-
-            # Group the axes atoms DOFs. From shape (batch,) to (batch, 1).
-            axes_atoms_dof = [dist_axis_atom.unsqueeze(1), dist_plane_atom.unsqueeze(1), angle.unsqueeze(1)]
-
-            # Flag axes atoms to be removed.
-            kept_atoms_mask[self._reference_atoms_indices_in_cartesian[-2:]] = False
-
-        # Remove reference atoms.
-        if self.has_origin_atom or self.has_axes_atoms:
-            x_cartesian = x_cartesian[:, kept_atoms_mask]
+        # Normalize the angle. angle is in [-pi, pi] so we use normalize_torsions().
+        # Normalize torsion takes and return shape (batch_size, 1), not (batch_size,).
+        a102, log_det_J = normalize_torsions(a102.unsqueeze(-1))
+        a102 = a102.squeeze(-1)
+        cumulative_log_det_J = cumulative_log_det_J + log_det_J.squeeze(-1)
 
         # From (batch, n_atoms, 3) to (batch, n_atoms*3).
         x_cartesian = atom_to_flattened(x_cartesian)
 
+        # Remove rototranslational DOFs.
+        mask = torch.full((x_cartesian.shape[1],), True).to(x_cartesian.device)
+        if self.remove_ref_rototranslation[0]:
+            mask[-9:-6] = False
+        if self.remove_ref_rototranslation[1]:
+            mask[-6:-3] = False
+        else:
+            mask[-6:-5] = False
+        if self.remove_ref_rototranslation[2]:
+            mask[-3:] = False
+        else:
+            mask[-3:-1] = False
+        x_cartesian = x_cartesian[:, mask]
+
         # Concatenate all DOFs.
-        y = torch.cat([bonds, angles, torsions] + axes_atoms_dof + [x_cartesian], dim=-1)
+        y = torch.cat([
+            bonds,
+            angles,
+            torsions,
+            d01.unsqueeze(1),
+            d02.unsqueeze(1),
+            a102.unsqueeze(1),
+            x_cartesian,
+        ], dim=-1)
 
         return y, cumulative_log_det_J, origin_atom_position, rotation_matrix
 
-    def _mixed_to_cartesian(
+    def mixed_to_cartesian(
             self,
             y: torch.Tensor,
             origin_atom_position: torch.Tensor,
             rotation_matrix: torch.Tensor,
     ) -> Tuple[torch.Tensor]:
-        """Convert from mixed to Cartesian."""
-        cumulative_log_det_J = 0
+        """Convert from mixed to Cartesian.
 
-        # Separate the IC and Cartesian DOFs.
-        bonds = y[:, :self.n_ic_atoms]
-        angles = y[:, self.n_ic_atoms:2*self.n_ic_atoms]
-        torsions = y[:, 2*self.n_ic_atoms:3*self.n_ic_atoms]
-        y_cartesian = y[:, 3*self.n_ic_atoms:]
+        Parameters
+        ----------
+        y : torch.Tensor
+            Shape ``(batch_size, n_atoms*3 - fixed_dofs)`` where ``fixed_dof``
+            can be 0, 3, or 6 depending on the value of ``self.remove_ref_rototranslation``
+            The mixed coordinates.
+        origin_atom_position : torch.Tensor
+            Shape ``(batch_size, 1, 3)``. The position of the origin of the
+            relative frame of reference in the original coordinate system.
+        rotation_matrix : torch.Tensor
+            Shape ``(batch_size, 1, 4)``. A rotation matrix representing the
+            rotation performed to transform the original coordinate system into
+            the relative one.
 
-        # Separate the axes atoms DOFs.
-        if self.has_axes_atoms:
-            dist_axis_atom, dist_plane_atom, angle, y_cartesian = y_cartesian.split(
-                [1, 1, 1, y_cartesian.shape[-1]-3], dim=-1)
+        Returns
+        -------
+        x : torch.Tensor
+            Shape ``(batch_size, n_atoms*3)`` or ``(batch_size, n_atoms, 3)``.
+            The Cartesian coordinates.
+        log_det_J : torch.Tensor
+            Shape ``(batch_size,)``. The logarithm of the absolute Jacobian
+            determinant of the coordinate transformation.
 
-            # Unnormalize the angle.
-            from bgflow.nn.flow.crd_transform.ic import unnormalize_torsions
-            angle, log_det_J = unnormalize_torsions(angle)
-            cumulative_log_det_J = cumulative_log_det_J + log_det_J
+        """
+        from bgflow.nn.flow.crd_transform.ic import unnormalize_torsions
+        batch_size = y.shape[0]
 
-            # From shape (batch_size, 1) to (batch_size,).
-            dist_axis_atom = dist_axis_atom.squeeze(-1)
-            dist_plane_atom = dist_plane_atom.squeeze(-1)
-            angle = angle.squeeze(-1)
+        # Separate the different types of coordinates.
+        bonds, angles, torsions, d01, d02, a102, y_cartesian = torch.tensor_split(
+            y, self._get_coords_indices_by_type()[:-1], dim=-1)
 
-        # From (batch, n_atoms*3) to (batch, n_atoms, 3).
-        y_cartesian = flattened_to_atom(y_cartesian)
+        # Unnormalize the angle.
+        a102, cumulative_log_det_J = unnormalize_torsions(a102)
 
-        # Find the positions of the reference atoms.
-        batch_size, n_cartesian_atoms, _ = y_cartesian.shape
-        reference_atom_positions = []
-        if self.has_origin_atom:
-            # We insert the origin since we'll translate also this later.
-            reference_atom_positions.append(torch.zeros_like(origin_atom_position))
-        if self.has_axes_atoms:
-            # The axis atom lies on the x-axis.
-            axis_atom_pos = torch.zeros(batch_size, 3).to(y_cartesian)
-            axis_atom_pos[:, 0] = dist_axis_atom
+        # From shape (batch_size, 1) to (batch_size,).
+        d01 = d01.squeeze(-1)
+        d02 = d02.squeeze(-1)
+        a102 = a102.squeeze(-1)
 
-            # The plane atom lies on the xy-plane.
-            x, y, log_det_J = polar_to_cartesian(
-                dist_plane_atom,
-                angle,
-                return_log_det_J=True,
-            )
-            plane_atom_pos = torch.zeros_like(axis_atom_pos)
-            plane_atom_pos[:, 0] = x
-            plane_atom_pos[:, 1] = y
+        # Create an array that includes the removed rototranslational DOFs.
+        n_cartesian_atoms_full = len(self.cartesian_atom_indices)
+        y_cartesian_full = torch.empty(batch_size, n_cartesian_atoms_full, 3).to(y_cartesian)
 
-            # Update.
-            reference_atom_positions.extend([axis_atom_pos, plane_atom_pos])
-            cumulative_log_det_J = cumulative_log_det_J + log_det_J
+        # Convert internal coords of the axes atoms to Cartesian.
+        origin_atom_idx, axis_atom_idx, plane_atom_idx = -3, -2, -1
+        y_cartesian_full[:, axis_atom_idx, 0] = d01
 
-        # Insert back into y_cartesian the reference atoms.
-        if len(reference_atom_positions) > 0:
-            y_cartesian_tmp = torch.empty(batch_size, n_cartesian_atoms+len(reference_atom_positions), 3).to(y_cartesian)
+        # The plane atom lies on the xy-plane.
+        plane_atom_x, plane_atom_y, log_det_J = polar_to_cartesian(
+            d02,
+            a102,
+            return_log_det_J=True,
+        )
+        y_cartesian_full[:, plane_atom_idx, 0] = plane_atom_x
+        y_cartesian_full[:, plane_atom_idx, 1] = plane_atom_y
+        cumulative_log_det_J = cumulative_log_det_J + log_det_J
 
-            # Start by setting the reference atom positions.
-            for idx, ref_atom_idx in enumerate(self._reference_atoms_indices_in_cartesian):
-                y_cartesian_tmp[:, ref_atom_idx] = reference_atom_positions[idx]
+        # Add back the translational DOFs.
+        mask = torch.full((n_cartesian_atoms_full, 3), True).to(y_cartesian.device)
+        if self.remove_ref_rototranslation[0]:
+            y_cartesian_full[:, origin_atom_idx] = 0.0
+            mask[origin_atom_idx] = False
 
-            # Now set the other Cartesian coordinates.
-            mask = torch.full(y_cartesian_tmp.shape[1:2], fill_value=True).to(
-                self._reference_atoms_indices_in_cartesian.device)
-            mask[self._reference_atoms_indices_in_cartesian] = False
-            y_cartesian_tmp[:, mask] = y_cartesian
+        # Add back the rotational DOFs.
+        if self.remove_ref_rototranslation[1]:
+            y_cartesian_full[:, axis_atom_idx, 1:] = 0.0
+            mask[axis_atom_idx] = False
+        else:
+            mask[axis_atom_idx, 0] = False
+        if self.remove_ref_rototranslation[2]:
+            y_cartesian_full[:, plane_atom_idx, 2] = 0.0
+            mask[plane_atom_idx] = False
+        else:
+            mask[plane_atom_idx, :2] = False
 
-            y_cartesian = y_cartesian_tmp
+        # Forward all other coordinates. Applying a 2d mask flattens that dimension.
+        y_cartesian_full[:, mask] = y_cartesian
+        y_cartesian_full = y_cartesian_full.reshape(batch_size, -1, 3)
 
         # Rotate and translate the Cartesian back to the global frame of reference.
-        if self.has_axes_atoms:
-            y_cartesian = batchwise_rotate(y_cartesian, rotation_matrix, inverse=True)
-        if self.has_origin_atom:
-            y_cartesian = y_cartesian + origin_atom_position.unsqueeze(1)
+        y_cartesian_full = batchwise_rotate(y_cartesian_full, rotation_matrix, inverse=True)
+        y_cartesian_full = y_cartesian_full + origin_atom_position.unsqueeze(1)
 
         # Convert internal coords back to Cartesian.
-        x, log_det_J = self._rel_ic(bonds, angles, torsions, y_cartesian, inverse=True)
+        x, log_det_J = self.rel_ic(bonds, angles, torsions, y_cartesian_full, inverse=True)
         cumulative_log_det_J = cumulative_log_det_J + log_det_J.squeeze(-1)
 
         return x, cumulative_log_det_J

--- a/tfep/nn/embeddings/__init__.py
+++ b/tfep/nn/embeddings/__init__.py
@@ -3,4 +3,4 @@ Embedding and encoder layers.
 """
 
 from tfep.nn.embeddings.radial import GaussianBasisExpansion, BehlerParrinelloRadialExpansion
-from tfep.nn.embeddings.mafembed import MAFEmbedding, PeriodicEmbedding
+from tfep.nn.embeddings.mafembed import MAFEmbedding, PeriodicEmbedding, FlipInvariantEmbedding

--- a/tfep/nn/embeddings/__init__.py
+++ b/tfep/nn/embeddings/__init__.py
@@ -3,4 +3,4 @@ Embedding and encoder layers.
 """
 
 from tfep.nn.embeddings.radial import GaussianBasisExpansion, BehlerParrinelloRadialExpansion
-from tfep.nn.embeddings.mafembed import MAFEmbedding, PeriodicEmbedding, FlipInvariantEmbedding
+from tfep.nn.embeddings.mafembed import MAFEmbedding, PeriodicEmbedding, FlipInvariantEmbedding, MixedEmbedding

--- a/tfep/nn/embeddings/mafembed.py
+++ b/tfep/nn/embeddings/mafembed.py
@@ -96,6 +96,10 @@ class PeriodicEmbedding(MAFEmbedding):
             periodic_indices = torch.arange(n_features_in)
         else:
             periodic_indices = ensure_tensor_sequence(periodic_indices)
+
+        # Check if there are repeated entries.
+        if len(periodic_indices.unique()) < len(periodic_indices):
+            raise ValueError('Found duplicated indices in periodic_indices.')
         self.register_buffer('_periodic_indices_in', periodic_indices)
 
         # We cache both periodic and nonperiodic indices in input and output.
@@ -231,6 +235,10 @@ class FlipInvariantEmbedding(MAFEmbedding):
             embedded_indices = torch.arange(n_features_in)
         else:
             embedded_indices = ensure_tensor_sequence(embedded_indices)
+
+        # Check if there are repeated entries.
+        if len(embedded_indices.unique()) < len(embedded_indices):
+            raise ValueError('Found duplicated indices in embedded_indices.')
         self.register_buffer('_embedded_indices_in', embedded_indices)
 
         # We need to cache both embedded and non-embedded indices before and

--- a/tfep/nn/embeddings/mafembed.py
+++ b/tfep/nn/embeddings/mafembed.py
@@ -15,10 +15,11 @@ Embedding layers for masked autoregressive flows (MAF).
 # =============================================================================
 
 import abc
+from collections.abc import Sequence
 
 import torch
 
-from tfep.utils.misc import ensure_tensor_sequence
+from tfep.utils.misc import ensure_tensor_sequence, remove_and_shift_sorted_indices
 
 
 # =============================================================================
@@ -167,3 +168,198 @@ class PeriodicEmbedding(MAFEmbedding):
         repeats = torch.ones_like(degrees_in)
         repeats[self._periodic_indices] = 2
         return torch.repeat_interleave(degrees_in, repeats)
+
+
+# =============================================================================
+# PERIODIC EMBEDDING
+# =============================================================================
+
+class FlipInvariantEmbedding(MAFEmbedding):
+    """Embeds vector features into a representation invariant to sign flips.
+
+    This implements the embedding proposed in [1] (Equation 46 in the SI).
+
+    References
+    ----------
+    [1] Köhler J, Invernizzi M, De Haan P, Noé F. Rigid body flows for sampling
+        molecular crystal structures. In International Conference on Machine
+        Learning 2023 Jul 3 (pp. 17301-17326). PMLR.
+
+    """
+
+    def __init__(
+            self,
+            n_features_in : int,
+            embedded_indices : Sequence[int],
+            embedding_dimension : int,
+            vector_dimension : int = 4,
+            hidden_layer_width : int = 32,
+    ):
+        """Constructor.
+
+        Parameters
+        ----------
+        n_features_in : int
+            Number of input features (embedded and not).
+        vector_dimension : int
+            The dimension of the embedded vectors.
+        embedded_indices : Sequence[int]
+            A sequence of length ``n_vectors*vector_dimension`` with the
+            (ordered) indices of the input features corresponding to the
+            vectors to embed. Vectors are assumed to be represented by
+            consecutive elements.
+        embedding_dimension : int
+            The embedding dimension of each vector.
+
+        """
+        super().__init__()
+
+        embedded_indices = ensure_tensor_sequence(embedded_indices)
+        self.register_buffer('_embedded_indices_in', embedded_indices)
+
+        # We need to cache both embedded and non-embedded indices
+        # before and after the transformation.
+        all_indices = torch.arange(n_features_in)
+        self.register_buffer('_nonembedded_indices_in', remove_and_shift_sorted_indices(
+            all_indices, removed_indices=embedded_indices, shift=False))
+
+        # Indices of the first component of the embedded input vectors.
+        vectors_first_indices_in = embedded_indices.reshape(-1, vector_dimension)[:, 0].tolist()
+
+        # Find embedded vectors indices after the embedding.
+        embedded_indices_out = []
+        dimension_diff = embedding_dimension - vector_dimension
+        shift_idx = 0
+        for first_idx_in in vectors_first_indices_in:
+            first_idx_out = shift_idx + first_idx_in
+            vector_indices_out = range(first_idx_out, first_idx_out+embedding_dimension)
+            embedded_indices_out.extend(list(vector_indices_out))
+            shift_idx += dimension_diff
+        self.register_buffer('_embedded_indices_out', torch.tensor(embedded_indices_out))
+
+        # Find the non-embedded feature indices after the embedding.
+        n_features_diff = len(vectors_first_indices_in) * dimension_diff
+        all_indices = torch.arange(n_features_in + n_features_diff)
+        self.register_buffer('_nonembedded_indices_out', remove_and_shift_sorted_indices(
+            all_indices, removed_indices=self._embedded_indices_out, shift=False))
+
+        # Create NNP layers for the embedding.
+        self.embedding_layer = torch.nn.Sequential(
+            torch.nn.Linear(vector_dimension, hidden_layer_width),
+            torch.nn.ELU(),
+            torch.nn.Linear(hidden_layer_width, embedding_dimension),
+        )
+        self.weight_layer = torch.nn.Sequential(
+            torch.nn.Linear(vector_dimension, hidden_layer_width),
+            torch.nn.ELU(),
+            torch.nn.Linear(hidden_layer_width, 1),
+            torch.nn.Softmax(),
+        )
+
+    @property
+    def vector_dimension(self) -> int:
+        """int: The input vector dimensionality."""
+        return self.embedding_layer[0].in_features
+
+    @property
+    def embedding_dimension(self) -> int:
+        """int: The embedding dimension for each vector."""
+        return self.embedding_layer[-1].out_features
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape ``(batch, n_features)``. Input tensor.
+
+        Returns
+        -------
+        y : torch.Tensor
+            Shape ``(batch, n_features + n_vectors*(embedded_dim - vector_dim))``.
+            The transformed features with the ``n_vectors`` vectors embedded
+            from the ``vector_dim`` to an ``embedded_dim`` space.
+
+        """
+        batch_size = x.shape[0]
+
+        # Extract vectors.
+        vectors = x[:, self._embedded_indices_in]
+
+        # From (batch, n_vectors*vector_dim) to (batch*n_vectors, vector_dim).
+        vectors = vectors.reshape(-1, self.vector_dimension)
+
+        # Find the positive and negative embeddings.
+        # Out shape is (batch*n_vectors, 2, embedding_dim).
+        embedded_vectors = torch.stack([
+            self.embedding_layer(vectors),
+            self.embedding_layer(-vectors)
+        ], dim=1)
+
+        # Find the softmax weights for the positive and negative embeddings.
+        # Out shape is (batch*n_vectors, 2, 1).
+        weights = torch.stack([
+            self.weight_layer(vectors),
+            self.weight_layer(-vectors),
+        ], dim=1)
+
+        # Weighted sum the positive and negative embeddings.
+        # Out shape is (batch*n_vectors, embedding_dim)
+        embedded_vectors = (weights * embedded_vectors).sum(dim=1)
+
+        # From (batch*n_vectors, embedding_dim) to (batch, n_vectors*embedding_dim).
+        embedded_vectors = embedded_vectors.reshape(batch_size, -1)
+
+        # Construct output tensor.
+        n_features_out = len(self._nonembedded_indices_out) + len(self._embedded_indices_out)
+        out = torch.empty((batch_size, n_features_out)).to(x)
+        out[:, self._embedded_indices_out] = embedded_vectors
+        out[:, self._nonembedded_indices_out] = x[:, self._nonembedded_indices_in]
+
+        return out
+
+    def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
+        """Return the degrees of the features after the forward pass.
+
+        This requires that all components of each vector is assigned a single
+        degree.
+
+        Parameters
+        ----------
+        degrees_in : torch.Tensor
+            Shape ``(n_features_in,)``. The degrees of the input features.
+
+        Returns
+        -------
+        degrees_out : torch.Tensor
+            Shape ``(n_features_out,)``. The degrees of the features after the
+            forward pass.
+
+        Raises
+        ------
+        ValueError
+            If there are some embedded vectors whose components have been
+            assigned different degrees.
+
+        """
+        # Get the degrees of the input vectors. Shape (n_vectors, vector_dimension).
+        vec_degrees_in = degrees_in[self._embedded_indices_in].reshape(-1, self.vector_dimension)
+
+        # All components of each vector must be assigned to the same degree.
+        if not torch.all(vec_degrees_in == vec_degrees_in[:, [0]]):
+            raise ValueError('The same degree must be assigned to all '
+                             'components of each embedded vectors.')
+
+        # Initialize the number of output features.
+        n_features_out = len(self._embedded_indices_out) + len(self._nonembedded_indices_out)
+        degrees_out = torch.empty(n_features_out, dtype=degrees_in.dtype).to(degrees_in)
+
+        # The degrees of the nonembedded features remain the same.
+        degrees_out[self._nonembedded_indices_out] = degrees_in[self._nonembedded_indices_in]
+
+        # The degrees of the embedded vectors are maintained but the change shape.
+        vec_degrees_out = vec_degrees_in[:, [0]].expand(-1, self.embedding_dimension)
+        degrees_out[self._embedded_indices_out] = vec_degrees_out.flatten()
+
+        return degrees_out

--- a/tfep/nn/embeddings/mafembed.py
+++ b/tfep/nn/embeddings/mafembed.py
@@ -224,7 +224,6 @@ class FlipInvariantEmbedding(MAFEmbedding):
             torch.nn.Linear(vector_dimension, hidden_layer_width),
             torch.nn.ELU(),
             torch.nn.Linear(hidden_layer_width, 1),
-            torch.nn.Softmax(),
         )
 
         # Embedded indices.
@@ -288,10 +287,10 @@ class FlipInvariantEmbedding(MAFEmbedding):
 
         # Find the softmax weights for the positive and negative embeddings.
         # Out shape is (batch*n_vectors, 2, 1).
-        weights = torch.stack([
+        weights = torch.softmax(torch.stack([
             self.weight_layer(vectors),
             self.weight_layer(-vectors),
-        ], dim=1)
+        ], dim=1), dim=1)
 
         # Weighted sum the positive and negative embeddings.
         # Out shape is (batch*n_vectors, embedding_dim)

--- a/tfep/nn/transformers/__init__.py
+++ b/tfep/nn/transformers/__init__.py
@@ -15,7 +15,9 @@ from tfep.nn.transformers.affine import (
 )
 from tfep.nn.transformers.mixed import MixedTransformer
 from tfep.nn.transformers.moebius import (
-    MoebiusTransformer, moebius_transformer)
+    MoebiusTransformer, moebius_transformer,
+    SymmetrizedMoebiusTransformer, symmetrized_moebius_transformer, symmetrized_moebius_transformer_inverse,
+)
 from tfep.nn.transformers.sos import (
     SOSPolynomialTransformer, SOSPolynomialTransformerFunc, sos_polynomial_transformer)
 from tfep.nn.transformers.spline import (

--- a/tfep/nn/transformers/__init__.py
+++ b/tfep/nn/transformers/__init__.py
@@ -18,6 +18,7 @@ from tfep.nn.transformers.moebius import (
     MoebiusTransformer, moebius_transformer,
     SymmetrizedMoebiusTransformer, symmetrized_moebius_transformer, symmetrized_moebius_transformer_inverse,
 )
+from tfep.nn.transformers.quatprod import QuaternionProductTransformer
 from tfep.nn.transformers.sos import (
     SOSPolynomialTransformer, SOSPolynomialTransformerFunc, sos_polynomial_transformer)
 from tfep.nn.transformers.spline import (

--- a/tfep/nn/transformers/moebius.py
+++ b/tfep/nn/transformers/moebius.py
@@ -543,7 +543,7 @@ def symmetrized_moebius_transformer_inverse(
 ) -> tuple[torch.Tensor]:
     r"""Inverse symmetrized Moebius transformer.
 
-    See :func:`.symmetrized_moebius_transformer_inverse` for documentation.
+    See :func:`.symmetrized_moebius_transformer` for the documentation.
 
     """
     # We solve the inversion first on the unit sphere, and then project back.

--- a/tfep/nn/transformers/moebius.py
+++ b/tfep/nn/transformers/moebius.py
@@ -53,8 +53,6 @@ class MoebiusTransformer(MAFTransformer):
         arXiv preprint arXiv:2002.02428. 2020 Feb 6.
 
     """
-    # Number of parameters needed by the transformer for each input dimension.
-    n_parameters_per_feature = 1
 
     def __init__(self, dimension: int, max_radius: float = 0.99, unit_sphere: bool = False):
         """Constructor.
@@ -170,7 +168,7 @@ class MoebiusTransformer(MAFTransformer):
             vector to perform the identity function with a Moebius transformer.
 
         """
-        return torch.zeros(size=(self.n_parameters_per_feature*n_features,))
+        return torch.zeros(size=(n_features,))
 
     def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
         """Returns the degrees associated to the conditioner's output.
@@ -189,7 +187,7 @@ class MoebiusTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_feature,))
+        return degrees_in.detach().clone()
 
 
 class SymmetrizedMoebiusTransformer(MAFTransformer):
@@ -227,8 +225,6 @@ class SymmetrizedMoebiusTransformer(MAFTransformer):
         arXiv preprint arXiv:2002.02428. 2020 Feb 6.
 
     """
-    # Number of parameters needed by the transformer for each input dimension.
-    n_parameters_per_feature = 1
 
     def __init__(
             self,
@@ -348,7 +344,7 @@ class SymmetrizedMoebiusTransformer(MAFTransformer):
             vector to perform the identity function with a Moebius transformer.
 
         """
-        par = torch.rand(self.n_parameters_per_feature*n_features)
+        par = torch.rand(n_features)
         return (2*par - 1) * self.identity_eps
 
     def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
@@ -368,7 +364,7 @@ class SymmetrizedMoebiusTransformer(MAFTransformer):
             transformer as parameters.
 
         """
-        return degrees_in.tile((self.n_parameters_per_feature,))
+        return degrees_in.detach().clone()
 
 
 # =============================================================================

--- a/tfep/nn/transformers/quatprod.py
+++ b/tfep/nn/transformers/quatprod.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Quaternion product transformation for autoregressive normalizing flows.
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import torch
+
+from tfep.nn.transformers.transformer import MAFTransformer
+
+
+# =============================================================================
+# QUATERNION PRODUCT TRANSFORMER
+# =============================================================================
+
+class QuaternionProductTransformer(MAFTransformer):
+    r"""Quaternion product transformer.
+
+    This is a volume-preserving transformation that can be applied to
+    quaternions. For each (normalized) quaternion in the input, the conditioner
+    must provide a 4-dimensional vector (possibly unnormalized). As quaternions
+    typically model the orientation of a molecule, the transformation is
+    equivalent to applying a separate rigid rotation to each molecule and thus
+    has a unit Jacobian.
+
+    """
+
+    def forward(self, x: torch.Tensor, parameters: torch.Tensor) -> tuple[torch.Tensor]:
+        """Apply the transformation.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape ``(batch_size, n_quaternions*4)``. The quaternions elements
+            are contiguous (i.e., the first and second input quaternions are
+            ``x[:4]`` and ``x[4:8]``.
+        parameters : torch.Tensor
+            Shape ``(batch_size, n_quaternions*4)``. The parameters interpreted
+            as (unnormalized) quaternions that will multiply those in ``x``.
+            These are normalized in the function.
+
+        Returns
+        -------
+        y : torch.Tensor
+            Shape ``(batch_size, n_quaternions*4)``. The transformed normalized
+            quaternions.
+        log_det_J : torch.Tensor
+            Shape ``(batch_size,)``. The logarithm of the absolute value of the Jacobian
+            determinant ``dy / dx`` (i.e., always zero).
+
+        """
+        # roma is an optional dependency at the moment
+        import roma
+
+        # From (batch, n_quaternions*4) to (batch*n_quaternions, 4).
+        batch_size = x.shape[0]
+        x = x.reshape(-1, 4)
+        parameters = parameters.reshape(-1, 4)
+
+        # Transform.
+        y = roma.quat_product(roma.quat_normalize(parameters), x)
+        log_det_J = torch.zeros(batch_size).to(x)
+        return y.reshape(batch_size, -1), log_det_J
+
+    def inverse(self, y: torch.Tensor, parameters: torch.Tensor) -> tuple[torch.Tensor]:
+        """Reverse the transformation.
+
+        Parameters
+        ----------
+        y : torch.Tensor
+            Shape ``(batch_size, n_quaternions*4)``. The quaternions elements
+            are contiguous (i.e., the first and second input quaternions are
+            ``y[:4]`` and ``y[4:8]``.
+        parameters : torch.Tensor
+            Shape ``(batch_size, n_quaternions*4)``. The parameters interpreted
+            as (unnormalized) quaternions that will multiply those in ``y``.
+            These are normalized in the function.
+
+        Returns
+        -------
+        x : torch.Tensor
+            Shape ``(batch_size, n_quaternions*4)``. The transformed normalized
+            quaternions.
+        log_det_J : torch.Tensor
+            Shape ``(batch_size,)``. The logarithm of the absolute value of the Jacobian
+            determinant ``dy / dx`` (i.e., always zero).
+
+        """
+        # roma is an optional dependency at the moment
+        import roma
+
+        # From (batch, n_quaternions*4) to (batch*n_quaternions, 4).
+        batch_size = y.shape[0]
+        y = y.reshape(-1, 4)
+        parameters = parameters.reshape(-1, 4)
+
+        # Transform.
+        x = roma.quat_product(roma.quat_conjugation(roma.quat_normalize(parameters)), y)
+        log_det_J = torch.zeros(batch_size).to(y)
+        return x.reshape(batch_size, -1), log_det_J
+
+    def get_identity_parameters(self, n_features: int) -> torch.Tensor:
+        """Return the value of the parameters that makes this the identity function.
+
+        This can be used to initialize the normalizing flow to perform the identity
+        transformation.
+
+        Parameters
+        ----------
+        n_features : int
+            The dimension of the input vector passed to the transformer. Must
+            be divisible by 4.
+
+        Returns
+        -------
+        parameters : torch.Tensor
+            A tensor of shape ``(n_features,)`` representing the parameter
+            vector to perform the identity function with a Moebius transformer.
+
+        """
+        # roma is an optional dependency at the moment
+        import roma
+        return roma.identity_quat(n_features//4).flatten()
+
+    def get_degrees_out(self, degrees_in: torch.Tensor) -> torch.Tensor:
+        """Returns the degrees associated to the conditioner's output.
+
+        Parameters
+        ----------
+        degrees_in : torch.Tensor
+            Shape ``(n_transformed_features,)``. The autoregressive degrees
+            associated to the features provided as input to the transformer.
+
+        Returns
+        -------
+        degrees_out : torch.Tensor
+            Shape ``(n_parameters,)``. The autoregressive degrees associated
+            to each output of the conditioner that will be fed to the
+            transformer as parameters.
+
+        """
+        return degrees_in.detach().clone()

--- a/tfep/nn/transformers/spline.py
+++ b/tfep/nn/transformers/spline.py
@@ -289,15 +289,11 @@ class NeuralSplineTransformer(MAFTransformer):
                              'implemented only if x0=y0 and xf=yf.')
 
         # The slopes parameters in _get_parameters are offset so that the final
-        # slope will be 1 when zeros are passed. This also sets the shifts to 0
-        # for periodic features/learnable domain and the domain scale (which
+        # slope will be 1 when zeros are passed. This also sets the 1) widths
+        # and heights (which go through a softmax) to equal bins; 2) shifts for
+        # periodic features/learnable domain to 0; and 3) the domain scale (which
         # goes through an exponential) to 1.
         id_conditioner = torch.zeros(size=(self.n_parameters_per_feature, n_features)).to(self.x0)
-
-        # Both the width and the height of each bin must be constant.
-        # Remember that the parameters go through the softmax function.
-        id_conditioner[:self.n_bins].fill_(1 / self.n_bins)
-        id_conditioner[self.n_bins:2*self.n_bins].fill_(1 / self.n_bins)
 
         return id_conditioner.reshape(-1)
 

--- a/tfep/tests/app/__init__.py
+++ b/tfep/tests/app/__init__.py
@@ -28,7 +28,7 @@ def check_atom_groups(
         expected_fixed: Optional[List[int]],
         expected_mapped_fixed_removed: Optional[List[int]],
         expected_conditioning_fixed_removed: Optional[List[int]],
-        is_deterministic_flow: bool = True,
+        round_trip: bool = True,
         **kwargs,
 ):
     """Test selection of mapped, conditioning, fixed, and reference frame atoms.
@@ -40,9 +40,9 @@ def check_atom_groups(
 
     Parameters
     ----------
-    is_deterministic_flow : bool, optional
-        If ``False``, this will not check that a forward-inverse round trip yields
-        the original input.
+    round_trip : bool, optional
+        If ``False``, this will not check that a forward-inverse round trip
+        yields the original input.
 
     """
     import lightning
@@ -128,7 +128,7 @@ def check_atom_groups(
     result = tfep_map({'positions': x})
     y, log_det_J = result['positions'], result['log_det_J']
     result = tfep_map.inverse({'positions': y})
-    if is_deterministic_flow:
+    if round_trip:
         x_inv, log_det_J_inv = result['positions'], result['log_det_J']
         assert torch.allclose(x, x_inv)
 

--- a/tfep/tests/app/test_cartesianmaf.py
+++ b/tfep/tests/app/test_cartesianmaf.py
@@ -105,3 +105,18 @@ def test_atom_groups(
         temperature=298*UNITS.kelvin,
         batch_size=2,
     )
+
+
+def test_error_origin_atom_not_conditioning():
+    """An error is raised if the origin atom is not a conditioning atom."""
+    tfep_map = CartesianMAFMap(
+        mapped_atoms=range(6),
+        origin_atom=1,
+        potential_energy_func=MockPotential(),
+        topology_file_path=CHLOROMETHANE_PDB_FILE_PATH,
+        coordinates_file_path=CHLOROMETHANE_PDB_FILE_PATH,
+        temperature=298*UNITS.kelvin,
+        batch_size=2,
+    )
+    with pytest.raises(ValueError, match="is not a conditioning atom"):
+        tfep_map.setup()

--- a/tfep/tests/app/test_maps.py
+++ b/tfep/tests/app/test_maps.py
@@ -130,25 +130,12 @@ def test_error_overlapping_atom_selections(tfep_map_cls):
 
 
 @pytest.mark.parametrize('tfep_map_cls', TESTED_TFEP_MAPS)
-def test_error_duplicate_atoms(tfep_map_cls):
-    """If mapped and conditioning atoms overlap, an error is raised."""
-    tfep_map = tfep_map_cls(mapped_atoms=[0, 0, 2], **MAP_INIT_KWARGS[tfep_map_cls.__name__])
-    with pytest.raises(ValueError, match='duplicate mapped atom'):
-        tfep_map.setup()
-
-    tfep_map = tfep_map_cls(conditioning_atoms=[3, 4, 4], **MAP_INIT_KWARGS[tfep_map_cls.__name__])
-    with pytest.raises(ValueError, match='duplicate conditioning atom'):
-        tfep_map.setup()
-
-
-@pytest.mark.parametrize('tfep_map_cls', TESTED_TFEP_MAPS)
-@pytest.mark.parametrize('origin_atom,axes_atoms', [
-    [0, (0, 2)],
-    [0, (2, 2)],
-    [0, (2, 0)],
-    [None, (1, 1)],
+@pytest.mark.parametrize('origin_atom,axes_atoms,match', [
+    [0, (0, 2), "must be different"],
+    [0, (2, 2), "2 axes atoms must be given"],
+    [0, (2, 0), "must be different"],
 ])
-def test_error_reference_frame_atoms_overlap(tfep_map_cls, origin_atom, axes_atoms):
+def test_error_reference_frame_atoms_overlap(tfep_map_cls, origin_atom, axes_atoms, match):
     """An error is raised if the origin, axis, and/or plane atoms overlap."""
     tfep_map = tfep_map_cls(
         conditioning_atoms=[0],
@@ -156,19 +143,7 @@ def test_error_reference_frame_atoms_overlap(tfep_map_cls, origin_atom, axes_ato
         axes_atoms=axes_atoms,
         **MAP_INIT_KWARGS[tfep_map_cls.__name__],
     )
-    with pytest.raises(ValueError, match="must be different"):
-        tfep_map.setup()
-
-
-@pytest.mark.parametrize('tfep_map_cls', TESTED_TFEP_MAPS)
-def test_error_origin_atom_not_conditioning(tfep_map_cls):
-    """An error is raised if the origin atom is not a conditioning atom."""
-    tfep_map = tfep_map_cls(
-        mapped_atoms=range(6),
-        origin_atom=1,
-        **MAP_INIT_KWARGS[tfep_map_cls.__name__],
-    )
-    with pytest.raises(ValueError, match="is not a conditioning atom"):
+    with pytest.raises(ValueError, match=match):
         tfep_map.setup()
 
 

--- a/tfep/tests/app/test_mixedmaf.py
+++ b/tfep/tests/app/test_mixedmaf.py
@@ -15,6 +15,7 @@ Test classes and functions in the ``tfep.app.mixedmaf`` module.
 # =============================================================================
 
 import os
+import random
 
 import MDAnalysis
 import numpy as np
@@ -22,18 +23,20 @@ import pint
 import pytest
 import torch
 
-from tfep.utils.misc import flattened_to_atom
 from tfep.app.mixedmaf import MixedMAFMap, _CartesianToMixedFlow
+import tfep.nn.transformers
+from tfep.utils.geometry import (
+    batchwise_rotate,
+    get_axis_from_name,
+    reference_frame_rotation_matrix,
+)
 
 from .. import DATA_DIR_PATH, MockPotential, benzoic_acid_universe, water_universe
 from . import check_atom_groups
 
 
 # bgflow is an optional dependency of the package.
-try:
-    import bgflow
-except ImportError:
-    pytest.skip('requires bgflow to be installed', allow_module_level=True)
+bgflow = pytest.importorskip('bgflow')
 
 
 # =============================================================================
@@ -64,6 +67,268 @@ def teardown_module(module):
 # =============================================================================
 # TEST UTILITIES
 # =============================================================================
+
+def create_z_matrix(
+        frags_n_atoms,
+        reference_atom_indices,
+        remove_ref_rototranslation,
+        consecutive_frag_atoms=True,
+        conditioning_atom_indices=None,
+):
+    """Generate test cases to test _CartesianToMixedFlow.
+
+    Parameters
+    ----------
+    frags_n_atoms : list[int]
+        frags_n_atoms[i] is the number of atoms in the i-th generated fragment.
+        Fragments up to 5 atoms are supported.
+    reference_atom_indices : list[int]
+    remove_ref_rototranslation : list[bool]
+    consecutive_frag_atoms : bool
+        If True, the atom indices belonging to a fragment have consecutive
+        indices. Otherwise, their order is scrambled.
+    conditioning_atom_indices : list[int]
+        The indices of the conditioning atoms.
+
+    Returns
+    -------
+    cartesian_atom_indices : torch.Tensor
+        Cartesian atom indices to initialize _CartesianToMixedFlow.
+    z_matrix : torch.Tensor
+        Z-matrix to initialize _CartesianToMixedFlow.
+    reference_atom_indices : list[int] or torch.Tensor
+        Reference atom indices to initialize _CartesianToMixedFlow. This is
+        different from the input argument only if consecutive_frag_atoms is
+        False.
+    cartesian_coords : torch.Tensor
+        Input cartesian coordinates.
+    mixed_coords : torch.Tensor
+        Expected mixed coordinates.
+    conditioning_atom_indices : torch.Tensor
+        The input for _CartesianToMixedFlow.get_dof_indices_by_type(). This is
+        different from conditioning_atom_indices only if consecutive_frag_atoms
+        is False.
+    mixed_dof_indices : Dict[str, torch.Tensor]
+        The expected result of _CartesianToMixedFlow.get_dof_indices_by_type().
+
+    """
+    # mixed coordinates are divided in
+    #   bonds, angles, torsions, d01, d02, a102, cartesian
+    # Angles and torsion must be normalized to [0, 1].
+    frags = [
+        # 1 atom.
+        {
+            'z_matrix': [[0, -1, -1, -1]],
+            'cartesian': [[0., 0., 0.]],
+            'ic': {
+                'bonds': [], 'angles': [], 'torsions': [],
+            },
+        },
+        # 2 atoms.
+        {
+            'z_matrix': [
+                [1, -1, -1, -1],
+                [0, 1, -1, -1],
+            ],
+            'cartesian': [[0., 0., 0.], [0.8, 0.8, 0.8]],
+            'ic': {
+                'bonds': [], 'angles': [], 'torsions': [],
+            },
+        },
+        # 3 atoms.
+        {
+            'z_matrix': [
+                [0, -1, -1, -1],
+                [2, 0, -1, -1],
+                [1, 0, 2, -1],
+            ],
+            'cartesian': [[1., 0., 0.], [0., 0., -1.], [0., 0., 0.]],
+            'ic': {
+                'bonds': [], 'angles': [], 'torsions': [],
+            },
+        },
+        # 4 atoms.
+        {
+            'z_matrix': [
+                [1, -1, -1, -1],
+                [0, 1, -1, -1],
+                [2, 1, 0, -1],
+                [3, 2, 0, 1],
+            ],
+            'cartesian': [[0., 0., 0.], [0., -1., 0.], [0., 0., 1.], [-1., 0., 0.]],
+            'ic': {
+                'bonds': [1.4142136], 'angles': [0.25], 'torsions': [0.25],
+            },
+        },
+        # 5 atoms.
+        {
+            'z_matrix': [
+                [3, -1, -1, -1],
+                [1, 3, -1, -1],
+                [0, 1, 3, -1],
+                [4, 1, 0, 3],
+                [2, 3, 4, 0],
+            ],
+            'cartesian': [[0., 0., 1.], [1., 1., 1.], [1., 0., 0.], [0., 0., 0.], [0., 1., 0.]],
+            'ic': {
+                'bonds': [1.4142136, 1.], 'angles': [0.3333333, 0.5], 'torsions': [0.59796, 0.25],
+            },
+        },
+    ]
+
+    # Used to find conditioning atoms.
+    if conditioning_atom_indices is None:
+        conditioning_atom_indices_set = set()
+    else:
+        conditioning_atom_indices_set = set(conditioning_atom_indices)
+
+    # Returned values.
+    z_matrix = []
+    cartesian_atom_indices = []
+    cartesian_coords = []
+    mixed_coords = {'bonds': [], 'angles': [], 'torsions': [], 'cartesians': []}
+    conditioning_dof_indices = []
+
+    # Keep track of the position of the three reference atoms.
+    ref_cartesian_coords = {}
+
+    # Build input arguments for _CartesianToMixedFlow.
+    atom_counts = np.cumsum([0] + frags_n_atoms)
+    for frag_idx, frag_n_atoms in enumerate(frags_n_atoms):
+        # To avoid overlapping and collinear atoms, we shift the Cartesian
+        # coordinates of each fragment randomly.
+        frag_cart_coords = torch.tensor(frags[frag_n_atoms-1]['cartesian'])
+        frag_cart_coords = frag_cart_coords + frag_idx*torch.rand(3)
+
+        # Concatenate input Cartesian coordinates.
+        cartesian_coords.append(frag_cart_coords)
+
+        # Shift atom indices to avoid duplicates among fragments.
+        frag_z_matrix = frags[frag_n_atoms-1]['z_matrix']
+        frag_z_matrix = (np.array(frag_z_matrix) + atom_counts[frag_idx]).tolist()
+
+        # Update Cartesian coords.
+        for row_idx, row in enumerate(frag_z_matrix):
+            atom_idx = row[0]
+            frag_atom_idx = atom_idx - atom_counts[frag_idx]
+            if (row_idx < 3) or atom_idx in conditioning_atom_indices_set:
+                # Cartesian
+                cartesian_atom_indices.append(atom_idx)
+                atom_cart_coords = frag_cart_coords[frag_atom_idx]
+
+                # Reference atoms are pushed at the end in the mixed coordinates.
+                if atom_idx in reference_atom_indices:
+                    ref_cartesian_coords[atom_idx] = atom_cart_coords
+                else:
+                    if atom_idx in conditioning_atom_indices_set:
+                        first_idx = 3 * len(mixed_coords['cartesians'])
+                        conditioning_dof_indices.extend(range(first_idx, first_idx+3))
+                    mixed_coords['cartesians'].append(atom_cart_coords.tolist())
+            else:
+                # Z-matrix
+                z_matrix.append(row)
+                for k in ['bonds', 'angles', 'torsions']:
+                    mixed_coords[k].append(frags[frag_n_atoms-1]['ic'][k][row_idx-3])
+
+    # Convert to tensor.
+    cartesian_atom_indices = torch.tensor(cartesian_atom_indices, dtype=int)
+    z_matrix = torch.tensor(z_matrix, dtype=int)
+    cartesian_coords = torch.cat(cartesian_coords)
+    mixed_coords = {k: torch.tensor(v) for k, v in mixed_coords.items()}
+
+    # From dict to list (in the order origin, axis, plane atoms).
+    ref_cartesian_coords = [ref_cartesian_coords[i] for i in reference_atom_indices]
+
+    # Rototranslate the cartesian into the relative reference frame.
+    v01 = (ref_cartesian_coords[1] - ref_cartesian_coords[0]).unsqueeze(0)
+    v02 = (ref_cartesian_coords[2] - ref_cartesian_coords[0]).unsqueeze(0)
+    rotation_matrix = reference_frame_rotation_matrix(
+        axis_atom_positions=v01,
+        plane_atom_positions=v02,
+        axis=get_axis_from_name('x'),
+        plane_axis=get_axis_from_name('y'),
+        project_on_positive_axis=True,
+    )
+    if len(mixed_coords['cartesians']) > 0:
+        mixed_coords['cartesians'] = mixed_coords['cartesians'] - ref_cartesian_coords[0]
+        mixed_coords['cartesians'] = batchwise_rotate(mixed_coords['cartesians'].unsqueeze(0), rotation_matrix)[0]
+        mixed_coords['cartesians'] = mixed_coords['cartesians'].flatten()
+
+    # Compute reference frame internal coordinates.
+    mixed_coords['d01'] = torch.linalg.norm(v01, dim=1)
+    mixed_coords['d02'] = torch.linalg.norm(v02, dim=1)
+
+    # Angle is normalized and in polar coordinates w.r.t. relative reference frame.
+    v02 = batchwise_rotate(v02.unsqueeze(0), rotation_matrix)[0]
+    mixed_coords['a102'] = (torch.atan2(v02[:, 1], v02[:, 0]) + np.pi) / (2*np.pi)
+
+    # Push at the cartesian coordinates (not removed) of the reference frame
+    # atoms and add conditioning reference frame atoms DOFs.
+    mixed_coords['reference'] = []
+    for idx, n_zeros in enumerate([3, 2, 1]):
+        if not remove_ref_rototranslation[idx]:
+            mixed_coords['reference'] = mixed_coords['reference'] + [0.]*n_zeros
+    mixed_coords['reference'] = torch.tensor(mixed_coords['reference'])
+
+    # DOF indices by type.
+    types_order = ['bonds', 'angles', 'torsions', 'd01', 'd02', 'a102', 'cartesians', 'reference']
+    first_idx = np.cumsum([len(mixed_coords[t]) for t in types_order]).tolist()
+    mixed_dof_indices = {
+        'd01': first_idx[2:3], 'd02': first_idx[3:4], 'a102': first_idx[4:5],
+    }
+    mixed_dof_indices.update({
+        'distances': list(range(first_idx[0])) + mixed_dof_indices['d01'] + mixed_dof_indices['d02'],
+        'angles': list(range(first_idx[0], first_idx[1])) + mixed_dof_indices['a102'],
+        'torsions': range(first_idx[1], first_idx[2]),
+        'cartesians': range(first_idx[5], first_idx[6]),
+        'reference': range(first_idx[6], first_idx[7]),
+    })
+    mixed_dof_indices = {k: torch.tensor(v, dtype=int) for k, v in mixed_dof_indices.items()}
+
+    # The indices in conditioning_dof_indices refer now to the indices in mixed_coords['cartesians'].
+    conditioning_dof_indices = [first_idx[5] + i for i in conditioning_dof_indices]
+
+    # Add conditioning reference frame atom internal coord DOFs indices.
+    if reference_atom_indices[2] in conditioning_atom_indices_set:
+        conditioning_dof_indices = first_idx[3:5] + conditioning_dof_indices
+    if reference_atom_indices[1] in conditioning_atom_indices_set:
+        conditioning_dof_indices = first_idx[2:3] + conditioning_dof_indices
+    if len(conditioning_dof_indices) > 0:
+        mixed_dof_indices['conditioning'] = torch.tensor(conditioning_dof_indices)
+    else:
+        mixed_dof_indices['conditioning'] = None
+
+    # Concatenate all mixed coordinates.
+    mixed_coords = torch.cat([mixed_coords[t] for t in types_order])
+
+    # Scramble the order of the input atom.
+    if not consecutive_frag_atoms:
+        # Generate a random permutation (without replacement).
+        n_atoms = atom_counts[-1].tolist()
+        permutation = torch.randperm(n_atoms)
+
+        # Fix the indices in the Z-matrix and cartesian atoms.
+        z_matrix = permutation[z_matrix]
+        reference_atom_indices = permutation[reference_atom_indices]
+        cartesian_atom_indices = permutation[cartesian_atom_indices]
+
+        # Fix the order in the input Cartesian coordinates.
+        cartesian_coords = cartesian_coords[permutation.sort().indices]
+
+        # Fix the conditioning Cartesian atom indices.
+        if conditioning_atom_indices is not None:
+            conditioning_atom_indices = permutation[conditioning_atom_indices].sort().values
+
+    return (
+        cartesian_atom_indices,
+        z_matrix,
+        reference_atom_indices,
+        cartesian_coords.flatten().unsqueeze(0),  # batch dimension
+        mixed_coords.unsqueeze(0),
+        conditioning_atom_indices,
+        mixed_dof_indices,
+    )
+
 
 class MyMixedMAFMap(MixedMAFMap):
     """A MixedMAFMap creating a solvated system.
@@ -114,8 +379,12 @@ class MyMixedMAFMap(MixedMAFMap):
 
     def _get_transformer(self, *args, **kwargs):
         mixed_transformer = super()._get_transformer(*args, **kwargs)
-        mixed_transformer._transformers[-1].x0 -= self.CARTESIAN_LIMIT_SHIFT
-        mixed_transformer._transformers[-1].xf += self.CARTESIAN_LIMIT_SHIFT
+        # Cartesian transformer is the only with a learnable upper bound.
+        for transformer in mixed_transformer._transformers:
+            if (isinstance(transformer, tfep.nn.transformers.NeuralSplineTransformer) and
+                    transformer._learn_lower_bound):
+                transformer.x0 -= self.CARTESIAN_LIMIT_SHIFT
+                transformer.xf += self.CARTESIAN_LIMIT_SHIFT
         return mixed_transformer
 
 
@@ -123,155 +392,167 @@ class MyMixedMAFMap(MixedMAFMap):
 # TESTS CartesianToMixedFlow
 # =============================================================================
 
-@pytest.mark.parametrize('origin,axes,conditioning,expected', [
-    (None, None, None, None),
-    (None, None, [1, 5, 6], [6, 7, 8, 15, 16, 17, 18, 19, 20]),
-    # Onl origin atom.
-    (2, None, [2], None),
-    (5, None, [1, 5, 6], [6, 7, 8, 15, 16, 17]),
-    # Both axes atoms are conditioning.
-    (None, [2, 5], [2, 5, 6], [6, 7, 8, 15, 16, 17]),
-    # Both axes atoms are mapped.
-    (None, [2, 5], [1], [9, 10, 11]),
-    # One axes atom is mapped the other is not.
-    (None, [2, 5], [4, 5], [7, 8, 12, 13, 14]),
-    (None, [2, 5], [1, 2, 6], [6, 9, 10, 11, 15, 16, 17]),
-    # Both origin and axes atoms.
-    (2, [5, 1], [1, 2, 5, 6], [6, 7, 8, 12, 13, 14]),
-    (2, [5, 1], [1, 2, 4], [7, 8, 9, 10, 11]),
-    (2, [5, 1], [2, 4, 5], [6, 9, 10, 11]),
-    (2, [5, 1], [2, 6], [12, 13, 14]),
+# Because of how the Z-matrix is built the reference atoms appear always as the
+# first atoms of the fragments' Z-matrices. We provide test cases consistently.
+@pytest.mark.parametrize('frags_n_atoms,reference_atom_indices', [
+    ([4], [1, 0, 2]),
+    ([5], [3, 1, 0]),
+    ([4, 3], [1, 0, 2]),
+    ([3, 4], [0, 2, 1]),
+    ([3, 4], [0, 2, 4]),
+    ([3, 3, 4], [0, 3, 7]),
+    ([3, 3, 4], [3, 5, 7]),
+    ([1, 3, 3, 4], [0, 1, 4]),
+    ([1, 3, 3, 4], [1, 8, 0]),
+    ([1, 4, 2, 3, 5], [2, 6, 5]),
+    ([1, 4, 2, 3, 5], [2, 1, 6]),
+    ([5, 1, 4, 3, 3, 3], [3, 1, 0]),
+    ([3, 2, 4, 5, 1, 1], [15, 14, 0]),
 ])
-def test_cartesian_to_mixed_flow_get_maf_conditioning_dof_indices(origin, axes, conditioning, expected):
-    """Test method _CartesianToMixedFlow.get_maf_conditioning_dof_indices()."""
-    # Convert to tensors.
-    origin, axes, conditioning, expected = [None if x is None else torch.tensor(x) for x in (origin, axes, conditioning, expected)]
+@pytest.mark.parametrize('remove_ref0', [True, False])
+@pytest.mark.parametrize('remove_ref1', [True, False])
+@pytest.mark.parametrize('remove_ref2', [True, False])
+@pytest.mark.parametrize('consecutive_frag_atoms', [True, False])
+def test_cartesian_to_mixed_flow_conversion(
+        frags_n_atoms,
+        reference_atom_indices,
+        remove_ref0,
+        remove_ref1,
+        remove_ref2,
+        consecutive_frag_atoms,
+):
+    """Test _CartesianToMixedFlow.cartesian_to_mixed()."""
+    remove_ref_rototranslation = [remove_ref0, remove_ref1, remove_ref2]
 
-    flow = _CartesianToMixedFlow(
-        flow=None,
-        cartesian_atom_indices=np.array([1, 2, 4, 5, 6]),
-        z_matrix=np.array([[3, 1, 5, 2], [0, 2, 3, 1]]),
-        origin_atom_idx=origin,
-        axes_atoms_indices=axes,
-    )
-    conditioning_indices = flow.get_maf_conditioning_dof_indices(conditioning_atom_indices=conditioning)
-
-    if expected is None:
-        assert conditioning_indices is expected
-    else:
-        assert torch.all(conditioning_indices == expected)
-
-
-@pytest.mark.parametrize('axes', [None, [1, 0], [3, 5]])
-def test_cartesian_to_mixed_flow_get_maf_angles_dof_indices(axes):
-    """Test method _CartesianToMixedFlow.get_maf_angles_dof_indices()."""
-    expected_angles = torch.tensor([2, 3])
-    expected_torsions = torch.tensor([4, 5])
-    if axes is not None:
-        axes = torch.tensor(axes)
-        expected_angles = torch.cat([expected_angles, torch.tensor([8])])
-
-    flow = _CartesianToMixedFlow(
-        flow=None,
-        cartesian_atom_indices=np.array([0, 1, 3, 4, 5]),
-        z_matrix=np.array([[2, 4, 0, 1], [6, 4, 2, 1]]),
-        origin_atom_idx=None,
-        axes_atoms_indices=axes,
-    )
-    angles_indices, periodic_indices = flow.get_maf_angles_dof_indices()
-
-    assert torch.all(angles_indices == expected_angles)
-    assert torch.all(periodic_indices == expected_torsions)
-
-
-@pytest.mark.parametrize('axes', [None, torch.tensor([1, 0])])
-def test_cartesian_to_mixed_flow_get_maf_distance_dof_indices(axes):
-    """Test method _CartesianToMixedFlow.get_maf_distance_dof_indices()."""
-    flow = _CartesianToMixedFlow(
-        flow=None,
-        cartesian_atom_indices=np.array([0, 1, 3, 4, 5]),
-        z_matrix=np.array([[2, 4, 0, 1], [6, 4, 2, 1]]),
-        origin_atom_idx=None,
-        axes_atoms_indices=axes,
-    )
-    distance_indices = flow.get_maf_distance_dof_indices()
-
-    expected = [0, 1]
-    if axes is not None:
-        expected.extend([6, 7])
-    assert torch.all(distance_indices == torch.tensor(expected))
-
-
-@pytest.mark.parametrize('origin', [None, 4, 7])
-@pytest.mark.parametrize('axes', [None, (2, 1), (9, 2), (0, 3)])
-def test_cartesian_to_mixed_flow_conversion(origin, axes):
-    """Test methods _CartesianToMixedFlow._mixed_to_cartesian() and ._cartesian_to_mixed()."""
-    batch_size, n_atoms = 2, 10
-    flow = _CartesianToMixedFlow(
-        flow=None,
-        cartesian_atom_indices=np.array([0, 1, 2, 3, 4, 5, 7, 9]),
-        z_matrix=np.array([[6, 2, 1, 4], [8, 1, 4, 2]]),
-        origin_atom_idx=None if origin is None else torch.tensor(origin),
-        axes_atoms_indices=None if axes is None else torch.tensor(axes),
+    # Create test case.
+    cartesian_atom_indices, z_matrix, reference_atom_indices, cartesian_coords, mixed_coords, _, _ = create_z_matrix(
+        frags_n_atoms,
+        reference_atom_indices,
+        remove_ref_rototranslation=remove_ref_rototranslation,
+        consecutive_frag_atoms=consecutive_frag_atoms,
+        conditioning_atom_indices=None,
     )
 
-    # Forward pass.
-    x = torch.rand(batch_size, n_atoms*3)
-    y, log_det_J, origin_atom_position, rotation_matrix = flow._cartesian_to_mixed(x)
+    # Create flow.
+    flow = _CartesianToMixedFlow(
+        flow=None,
+        cartesian_atom_indices=cartesian_atom_indices,
+        z_matrix=z_matrix,
+        reference_atom_indices=reference_atom_indices,
+        remove_ref_rototranslation=remove_ref_rototranslation,
+    )
 
-    # Bonds and distances are greater than 0.
-    distance_dofs = flow.get_maf_distance_dof_indices()
-    assert torch.all(y[:, distance_dofs] >= 0)
+    # Convert coordinates.
+    cartesian_coords = cartesian_coords.detach()
+    cartesian_coords.requires_grad = True
+    converted, log_det_J, global_origin, global_rotation_quat = flow.cartesian_to_mixed(cartesian_coords)
+    assert torch.allclose(converted, mixed_coords)
 
-    # Periodic indices are normalized angles within 0 and 1.
-    angles_dofs, periodic_dofs = flow.get_maf_angles_dof_indices()
-    assert torch.all(y[:, angles_dofs] >= 0)
-    assert torch.all(y[:, angles_dofs] <= 1)
+    # Convert back.
+    cartesian_inv, log_det_J_inv = flow.mixed_to_cartesian(converted, global_origin, global_rotation_quat)
+    assert torch.allclose(cartesian_coords, cartesian_inv)
+    assert torch.allclose(log_det_J+log_det_J_inv, torch.zeros_like(log_det_J))
 
-    # With origin and/or axes atoms the total number of DOFs is reduced.
-    expected_n_dofs = x.shape[1]
-    if flow.has_origin_atom:
-        expected_n_dofs -= 3
-    if flow.has_axes_atoms:
-        expected_n_dofs -= 3
-    assert y.shape == (batch_size, expected_n_dofs)
 
-    # Without origin and axes atoms, all Cartesian coordinates are invariant.
-    if not (flow.has_origin_atom or flow.has_axes_atoms):
-        x_cartesian = flattened_to_atom(x)[:, flow.cartesian_atom_indices]
-        y_cartesian = flattened_to_atom(y)[:, flow.n_ic_atoms:]
-        assert torch.allclose(x_cartesian, y_cartesian)
+@pytest.mark.parametrize('frags_n_atoms,reference_atom_indices', [
+    ([4], [1, 0, 2]),
+    ([5], [3, 1, 0]),
+    ([4, 3], [1, 0, 2]),
+    ([3, 4], [0, 2, 1]),
+    ([3, 4], [0, 2, 4]),
+    ([3, 3, 4], [0, 3, 7]),
+    ([3, 3, 4], [3, 5, 7]),
+    ([1, 3, 3, 4], [0, 1, 4]),
+    ([1, 3, 3, 4], [1, 8, 0]),
+    ([1, 4, 2, 3, 5], [2, 6, 5]),
+    ([1, 4, 2, 3, 5], [2, 1, 6]),
+    ([5, 1, 4, 3, 3, 3], [3, 1, 0]),
+    ([3, 2, 4, 5, 1, 1], [15, 14, 0]),
+])
+@pytest.mark.parametrize('n_conditioning_atoms', [0, 1, 2, 3])
+@pytest.mark.parametrize('remove_ref0', [True, False])
+@pytest.mark.parametrize('remove_ref1', [True, False])
+@pytest.mark.parametrize('remove_ref2', [True, False])
+@pytest.mark.parametrize('consecutive_frag_atoms', [True, False])
+def test_cartesian_to_mixed_flow_get_dof_indices_by_type(
+        frags_n_atoms,
+        reference_atom_indices,
+        n_conditioning_atoms,
+        remove_ref0,
+        remove_ref1,
+        remove_ref2,
+        consecutive_frag_atoms,
+):
+    """Test _CartesianToMixedFlow.get_dof_indices_by_type()."""
+    remove_ref_rototranslation = [remove_ref0, remove_ref1, remove_ref2]
 
-    # Test inversion.
-    x_inv, log_det_J_inv = flow._mixed_to_cartesian(y, origin_atom_position, rotation_matrix)
-    assert torch.allclose(x, x_inv)
+    # We need to have at least 1 atom represented by the Z-matrix, but some
+    # choices of conditioning_atom_indices might lead to all-cartesian coords.
+    n_atoms = sum(frags_n_atoms)
+    cartesian_atom_indices = [None] * n_atoms
+    while len(cartesian_atom_indices) == n_atoms:
+        if n_conditioning_atoms == 0:
+            conditioning_atom_indices = None
+        else:
+            conditioning_atom_indices = sorted(random.sample(range(n_atoms), n_conditioning_atoms))
 
-    # Total Jacobian determinant of forward+inverse without a flow should be one.
-    assert torch.allclose(log_det_J + log_det_J_inv, torch.zeros_like(log_det_J))
+        # Create test case.
+        cartesian_atom_indices, z_matrix, reference_atom_indices_in, _, _, conditioning_atom_indices, mixed_dof_indices = create_z_matrix(
+            frags_n_atoms,
+            reference_atom_indices,
+            remove_ref_rototranslation=remove_ref_rototranslation,
+            consecutive_frag_atoms=consecutive_frag_atoms,
+            conditioning_atom_indices=conditioning_atom_indices,
+        )
+
+    # Create flow.
+    flow = _CartesianToMixedFlow(
+        flow=None,
+        cartesian_atom_indices=cartesian_atom_indices,
+        z_matrix=z_matrix,
+        reference_atom_indices=reference_atom_indices_in,
+        remove_ref_rototranslation=remove_ref_rototranslation,
+    )
+
+    # get_dof_indices_by_type requires a tensor.
+    if conditioning_atom_indices is not None:
+        conditioning_atom_indices = torch.tensor(conditioning_atom_indices)
+
+    # Check dof indices.
+    dof_indices = flow.get_dof_indices_by_type(conditioning_atom_indices)
+    assert len(dof_indices) == len(mixed_dof_indices)
+    for k, v in dof_indices.items():
+        if v is None:
+            assert mixed_dof_indices[k] is None
+        else:
+            assert torch.allclose(v, mixed_dof_indices[k])
 
 
 # =============================================================================
 # TESTS MixedMAFMap
 # =============================================================================
 
-@pytest.mark.parametrize('mapped_atoms,conditioning_atoms,origin_atom,axes_atoms,expected_z_matrix', [
+@pytest.mark.parametrize('mapped_atoms,conditioning_atoms,origin_atom,axes_atoms,expected_z_matrix,expected_ref_atom_indices', [
     # Chloromethane is mapped. Everything else is fixed. No origin/axes.
     ('resname CLMET',
      None,
      None, None,
-     [[3, 0, 2, 1], [4, 0, 3, 2]]
+     [[3, 0, 2, 1], [4, 0, 3, 2]],
+     [0, 1, 2],
      ),
     # Map separable parts of benzoic acid. Everything else is fixed. No origin/axes.
     ('resname BEN and (name H3 or name C3 or name C4 or name H4 or name HO2 or name O2 or name C or name O1)',
      None,
      None, None,
-     [[5, 2, 0, 1], [7, 4, 3, 6]]
+     [[5, 2, 0, 1], [7, 4, 3, 6]],
+     [0, 1, 2],
      ),
     # Map multiple molecules: chloromethane, water, and F. Everything else is fixed. No origin/axes.
     ('resname CLMET or resname WAT1 or resname F',
      None,
      None, None,
-     [[3, 0, 2, 1], [4, 0, 3, 2]]
+     [[3, 0, 2, 1], [4, 0, 3, 2]],
+     [0, 1, 2],
      ),
     # Map multiple molecules: benzoic acid and chloromethane. Everything else is fixed. No origin/axes.
     ('resname BEN or resname CLMET',
@@ -292,7 +573,9 @@ def test_cartesian_to_mixed_flow_conversion(origin, axes):
          [12, 6, 7, 5],
          [18, 15, 17, 16],
          [19, 15, 18, 17],
-     ]),
+     ],
+     [3, 0, 4],
+     ),
     # Condition benzoic acid's H atoms on its other atoms.
     ('resname BEN and element H',
      'resname BEN and not element H',
@@ -304,42 +587,64 @@ def test_cartesian_to_mixed_flow_conversion(origin, axes):
          [11, 5, 6, 4],
          [13, 7, 6, 8],
          [12, 6, 7, 5],
-     ]),
+     ],
+     [3, 0, 4],
+     ),
     # Set the origin atom.
+    ('resname BEN and element C',
+     None,
+     'resname BEN and name C4', None,
+      [[2, 3, 4, 5], [6, 5, 4, 2], [1, 6, 2, 5], [0, 1, 6, 2]],
+     [4, 3, 5],
+     ),
+    # Conditioning origin atom.
     ('resname BEN and element C and not name C4',
      'resname BEN and name C4',
      'resname BEN and name C4', None,
-      [[2, 3, 4, 5], [6, 5, 4, 2], [1, 6, 2, 5], [0, 1, 6, 2]]
+      [[2, 3, 4, 5], [6, 5, 4, 2], [1, 6, 2, 5], [0, 1, 6, 2]],
+     [4, 3, 5],
      ),
-    # Set as axes atom the C3 and C5 atoms of benzoic acid.
+    # Set origin and axes atom.
     ('resname BEN and element C',
      None,
-     None, 'resname BEN and (name C3 or name C5)',
-      [[4, 5, 3, 2], [1, 2, 3, 5], [0, 1, 2, 5], [6, 1, 5, 0]]
+     'resname BEN and name C2', 'resname BEN and (name C3 or name C5)',
+     [[1, 2, 3, 5], [0, 1, 2, 5], [6, 1, 5, 0], [4, 5, 3, 6]],
+     [2, 3, 5],
      ),
-    # Axes atom bonded.
+    # Conditioning origin with mapped axes atom.
     ('resname BEN and element C and not name C6',
      'resname BEN and name C6',
      'resname BEN and name C6', 'resname BEN and (name C1 or name C5)',
       [[0, 1, 6, 5], [2, 1, 0, 6], [4, 5, 6, 2], [3, 4, 2, 5]],
+     [6, 1, 5],
      ),
-    # Origin and axes are distant on the same molecule.
-    ('resname BEN and element C and not name C1',
-     'resname BEN and name C1',
+    # Conditioning axes atoms with mapped origin.
+    ('resname BEN and element C and not (name C3 or name C4)',
+     'resname BEN and (name C3 or name C4)',
+     'resname BEN and name C2', 'resname BEN and (name C3 or name C4)',
+     [[1, 2, 3, 4], [0, 1, 2, 3], [6, 1, 0, 2], [5, 6, 4, 1]],
+     [2, 3, 4],
+     ),
+    # All reference atoms are conditioning.
+    ('resname BEN and element C and not (name C1 or name C or name C5)',
+     'resname BEN and (name C1 or name C or name C5)',
      'resname BEN and name C1', 'resname BEN and (name C or name C5)',
       [[2, 1, 0, 5], [6, 5, 1, 2], [3, 2, 1, 5], [4, 3, 5, 2]],
+     [1, 0, 5],
      ),
     # Origin and axes are on different mapped molecules.
-    ('(resname BEN and element C) or (resname CLMET and not name C1)',
-     'resname CLMET and name C1',
+    ('(resname BEN and element C) or resname CLMET',
+     None,
      'resname CLMET and name C1', 'resname BEN and (name C1 or name C6)',
-      [[2, 1, 0, 6], [3, 2, 1, 0], [5, 6, 1, 3], [4, 5, 3, 6], [10, 7, 9, 8], [11, 7, 10, 9]]
+      [[2, 1, 0, 6], [3, 2, 1, 0], [5, 6, 1, 3], [4, 5, 3, 6], [10, 7, 9, 8], [11, 7, 10, 9]],
+     [7, 1, 6],
      ),
     # Origin and bonded axes atom are different conditioning molecules.
     ('resname CLMET',
      'resname WAT1',
      'resname WAT1 and name O', '(resname CLMET and name H3) or (resname WAT1 and name H2)',
-      [[2, 0, 1, 4], [3, 0, 2, 1]]
+      [[2, 0, 1, 4], [3, 0, 2, 1]],
+     [5, 4, 7],
      ),
 ])
 def test_mixed_maf_flow_build_z_matrix(
@@ -348,6 +653,7 @@ def test_mixed_maf_flow_build_z_matrix(
         origin_atom,
         axes_atoms,
         expected_z_matrix,
+        expected_ref_atom_indices,
 ):
     """MixedMAFMap correctly converts the coordinates into Cartesian+internal DOFs."""
     # Initialize the map.
@@ -373,7 +679,8 @@ def test_mixed_maf_flow_build_z_matrix(
     n_cartesian_atoms = len(cartesian_atom_indices)
 
     # Check that we determine the correct Z-matrix.
-    assert (cartesian_to_mixed_flow.z_matrix == expected_z_matrix).all()
+    assert torch.allclose(cartesian_to_mixed_flow.z_matrix, torch.tensor(expected_z_matrix))
+    assert torch.allclose(cartesian_to_mixed_flow.rel_ic.fixed_atoms[-3:], torch.tensor(expected_ref_atom_indices))
 
     # The Z-matrix and fixed atoms cover all the mapped + conditioning atoms.
     n_expected_atoms = tfep_map.n_mapped_atoms + tfep_map.n_conditioning_atoms
@@ -381,8 +688,11 @@ def test_mixed_maf_flow_build_z_matrix(
     assert len(set(ic_atom_indices) | set(cartesian_atom_indices)) == n_expected_atoms
 
 
-@pytest.mark.parametrize('fix_origin', [False, True])
-@pytest.mark.parametrize('fix_orientation', [False, True])
+@pytest.mark.parametrize('fix_origin,fix_orientation', [
+    (False, False),
+    (True, False),
+    (True, True),
+])
 @pytest.mark.parametrize('mapped_atoms,conditioning_atoms,expected_mapped,expected_conditioning,expected_fixed,expected_mapped_fixed_removed,expected_conditioning_fixed_removed', [
     # If neither mapped nor conditioning are given, all atoms are mapped.
     (None, None, list(range(15)), None, None, list(range(15)), None),
@@ -399,7 +709,7 @@ def test_mixed_maf_flow_build_z_matrix(
     (torch.tensor([1, 3, 4, 5, 6]), [2]+list(range(7, 14)), [1, 3, 4, 5, 6], [2]+list(range(7, 14)), [0, 14], [0, 2, 3, 4, 5], [1]+list(range(6, 13))),
     ([0, 3, 4, 8, 14], np.array([1, 5]), [0, 3, 4, 8, 14], [1, 5], [2, 6, 7, 9, 10, 11, 12, 13], [0, 2, 3, 5, 6], [1, 4]),
 ])
-def test_atom_groups(
+def test_mixed_maf_flow_atom_groups(
         fix_origin,
         fix_orientation,
         mapped_atoms,
@@ -413,6 +723,8 @@ def test_atom_groups(
     """Mapped, conditioning, fixed, and reference frame atoms are selected and handled correctly."""
     check_atom_groups(
         tfep_map_cls=MyMixedMAFMap,
+        # Currently, the test picks only conditioning origin atoms and assumes
+        # that the translational/rotationa DOFs are kept fixed
         fix_origin=fix_origin,
         fix_orientation=fix_orientation,
         mapped_atoms=mapped_atoms,
@@ -426,71 +738,68 @@ def test_atom_groups(
         # MixedMAFMap kwargs.
         batch_size=1,
         benzoic_acid_only=True,
+        remove_translation=True,
+        remove_rotation=True,
     )
 
 
-def test_mixed_maf_flow_auto_reference_atoms():
-    """Origin and axes atoms are automatically selected if requested."""
-    tfep_map = MyMixedMAFMap(
-        batch_size=2,
-        mapped_atoms='resname CLMET',
-        conditioning_atoms='resname F',
-        auto_reference_frame=True,
-    )
-    tfep_map.setup()
-    assert tfep_map.get_reference_atoms_indices(remove_fixed=True).tolist() == [0, 1, 2]
-
-    # The origin atom has been converted to a conditioning DOF.
-    assert tfep_map._origin_atom_idx in tfep_map._conditioning_atom_indices
-    assert tfep_map._origin_atom_idx not in tfep_map._mapped_atom_indices
-
-
-@pytest.mark.parametrize('origin_atom', [False, True])
-@pytest.mark.parametrize('axes_atoms', [
-    None,
-    'resname BEN and (name C3 or name C5)',
-    'resname BEN and (name C3 or name C6)',
-    'resname BEN and (name C2 or name C3)',
-    'resname BEN and (name C2 or name C1)',
+@pytest.mark.parametrize('origin_atom,axes_atoms', [
+    (False, None),
+    (True, None),
+    (True, 'resname BEN and (name C3 or name C5)'),
+    (True, 'resname BEN and (name C3 or name C6)'),
+    (True, 'resname BEN and (name C2 or name C3)'),
+    (True, 'resname BEN and (name C2 or name C1)'),
 ])
-def test_mixed_maf_flow_get_transformer(origin_atom, axes_atoms):
+@pytest.mark.parametrize('conditioning_atoms', [False, True])
+@pytest.mark.parametrize('two_fragments', [False, True])
+@pytest.mark.parametrize('remove_translation', [False, True])
+@pytest.mark.parametrize('remove_rotation', [False, True])
+def test_mixed_maf_flow_get_transformer(
+        origin_atom,
+        axes_atoms,
+        conditioning_atoms,
+        two_fragments,
+        remove_translation,
+        remove_rotation,
+):
     """The limits of the neural spline transformer are constructed correctly."""
     # MockPotential default positions unit is angstrom.
-    distance_lower_limit_displacement = 0.2  # in Angstrom
+    distance_lower_limit_displacement = 0.2
 
     mapped_atoms = 'resname BEN and element C'
-    if origin_atom:
-        mapped_atoms += ' and not name C4'
-        origin_atom = 'resname BEN and name C4'
-        conditioning_atoms = '(resname BEN and element O) or (' + origin_atom + ')'
-    else:
-        origin_atom = None
-        conditioning_atoms = 'resname BEN and element O'
+    if two_fragments:
+         mapped_atoms = f'(({mapped_atoms}) or resname WAT1)'
+    origin_atom = 'resname BEN and name C4' if origin_atom else None
+    conditioning_atoms = 'resname BEN and element O' if conditioning_atoms else None
 
+    # Create map.
     tfep_map = MyMixedMAFMap(
         batch_size=2,
         mapped_atoms=mapped_atoms,
         conditioning_atoms=conditioning_atoms,
         origin_atom=origin_atom,
         axes_atoms=axes_atoms,
+        remove_translation=remove_translation,
+        remove_rotation=remove_rotation,
         distance_lower_limit_displacement=distance_lower_limit_displacement * UNITS.angstrom,
     )
     tfep_map.setup()
 
     # Get transformer.
     mixed_transformer = tfep_map._flow.flow.flow[0]._transformer
-    distance_spl, angle_spl, torsion_spl, cartesian_spl = mixed_transformer._transformers
+    transformers = mixed_transformer._transformers
+    distance_spl, angle_spl, torsion_spl = transformers[:3]
 
     # There are always 4 bonds/angles/torsions.
     n_ic = 4
 
     # Check lengths.
-    assert len(distance_spl.x0) == n_ic + 2 * (axes_atoms is not None)
-    assert len(angle_spl.x0) == n_ic + 1 * (axes_atoms is not None)
+    assert len(distance_spl.x0) == n_ic + 2
+    assert len(angle_spl.x0) == n_ic + 1
     assert len(torsion_spl.x0) == n_ic
-    assert len(cartesian_spl.x0) == tfep_map.n_mapped_dofs - 3 * n_ic - 3 * (axes_atoms is not None)
 
-    # Check bond limits. There are no bonds less than 1.35 or greater than 1.5 A.
+    # Check bond limits. Benzoic acid has no bonds less/greater than 1.35/1.5 A.
     assert torch.all(distance_spl.x0[:n_ic] > torch.tensor(1.35 - distance_lower_limit_displacement))
     assert torch.all(distance_spl.xf[:n_ic] < torch.tensor(1.5))
 
@@ -505,38 +814,103 @@ def test_mixed_maf_flow_get_transformer(origin_atom, axes_atoms):
     assert torch.all(mixed_transformer._indices2 == torch.tensor(expected_circular_indices))
 
     # Check if there are the axes atoms DOFs after the internal coordinates.
-    if axes_atoms is not None:
-        for axes_atom_idx in range(2):
-            # The limits depends on the value during the simulation.
-            positions = tfep_map.dataset.universe.trajectory[0].positions
-            axes_pos = positions[tfep_map._axes_atoms_indices[axes_atom_idx].tolist()]
+    for axes_atom_idx in range(2):
+        # The limits depends on the value during the simulation.
+        positions = tfep_map.dataset.universe.trajectory[0].positions
+        axes_pos = positions[tfep_map._axes_atoms_indices[axes_atom_idx].tolist()]
 
-            # Find distance.
-            if origin_atom is not None:
-                axes_pos = axes_pos - positions[tfep_map._origin_atom_idx.tolist()]
-            axes_dist = np.linalg.norm(axes_pos).tolist()
+        # Find distance.
+        axes_pos = axes_pos - positions[tfep_map._origin_atom_idx.tolist()]
+        axes_dist = np.linalg.norm(axes_pos).tolist()
 
-            idx = n_ic + axes_atom_idx
-            assert np.isclose(distance_spl.x0[idx].tolist(), max(0.0, axes_dist-distance_lower_limit_displacement), atol=1e-5)
-            assert np.isclose(distance_spl.xf[idx].tolist(), axes_dist, atol=1e-5)
+        idx = n_ic + axes_atom_idx
+        assert np.isclose(distance_spl.x0[idx].tolist(), max(0.0, axes_dist-distance_lower_limit_displacement), atol=1e-5)
+        assert np.isclose(distance_spl.xf[idx].tolist(), axes_dist, atol=1e-5)
 
-    # The other mapped and conditioning are treated as Cartesian. There is only
-    # 1 frame in the trajectory so the min and max value for the DOF is the same.
-    # MyMixedMAF shifts the lower limit since there is only 1 frame in the trajectory.
-    assert torch.allclose(
-        cartesian_spl.x0 + tfep_map.CARTESIAN_LIMIT_SHIFT,
-        cartesian_spl.xf - tfep_map.CARTESIAN_LIMIT_SHIFT,
+    # Check if there are Cartesian.
+    if two_fragments:
+        cartesian_spl = transformers[3]
+        assert len(cartesian_spl.x0) == 9
+
+        # The other mapped and conditioning are treated as Cartesian. There is only
+        # 1 frame in the trajectory so the min and max value for the DOF is the same.
+        # MyMixedMAF shifts the lower limit since there is only 1 frame in the trajectory.
+        assert torch.allclose(
+            cartesian_spl.x0 + tfep_map.CARTESIAN_LIMIT_SHIFT,
+            cartesian_spl.xf - tfep_map.CARTESIAN_LIMIT_SHIFT,
+        )
+
+    # Check if there are references Cartesian DOFs.
+    if not (remove_translation and remove_rotation):
+        reference_vpt = transformers[-1]
+        assert isinstance(reference_vpt, tfep.nn.transformers.VolumePreservingShiftTransformer)
+        expected_len = 6 - 3*remove_translation - 3*remove_rotation
+        assert len(getattr(mixed_transformer, '_indices' + str(len(transformers)-1))) == expected_len
+
+
+@pytest.mark.parametrize('conditioning_atoms', [None, 'BEN', 'WAT1'])
+@pytest.mark.parametrize('remove_translation', [False, True])
+@pytest.mark.parametrize('remove_rotation', [False, True])
+def test_mixed_maf_flow_get_maf_degrees_in(conditioning_atoms, remove_translation, remove_rotation):
+    """The input degrees for MAF returned by MixedMAFFlow._get_maf_degrees_in are correct.
+
+    In particular, the reference DOFs (if present) get always assigned the last degree.
+
+    """
+    mapped_atoms = 'resname BEN'
+    if conditioning_atoms is None:
+        mapped_atoms += ' or resname WAT1'
+    elif conditioning_atoms == 'BEN':
+        mapped_atoms += ' and not (name C or name C1 or name C2) or resname WAT1'
+        conditioning_atoms = 'resname BEN and (name C or name C1 or name C2)'
+    elif conditioning_atoms == 'WAT1':
+        conditioning_atoms = 'resname WAT1'
+
+    # Create the class and get the indices by type the CartesianToMixedFlow.
+    tfep_map = MyMixedMAFMap(
+        mapped_atoms=mapped_atoms,
+        conditioning_atoms=conditioning_atoms,
+        remove_translation=remove_translation,
+        remove_rotation=remove_rotation,
+    )
+    tfep_map.setup()
+    cartesian_to_mixed_flow = tfep_map._flow.flow
+    maf_dof_indices = cartesian_to_mixed_flow.get_dof_indices_by_type(
+        tfep_map.get_conditioning_indices(idx_type='atom', remove_fixed=True))
+
+    # Get the degrees in.
+    degrees_in = tfep_map._get_maf_degrees_in(
+        n_dofs_in=cartesian_to_mixed_flow.n_dofs_out,
+        maf_dof_indices=maf_dof_indices,
     )
 
+    for degree in degrees_in:
+        # There are reference input DOFs only if they are mapped and
+        # remove_translation/rotation is False.
+        is_ben_conditioning = (conditioning_atoms is not None) and ('BEN' in conditioning_atoms)
+        n_references = len(maf_dof_indices['reference'])
+        if is_ben_conditioning or (remove_translation and remove_rotation):
+            assert n_references == 0
+        elif not (remove_translation or remove_rotation):
+            assert n_references == 6
+        else:
+            assert n_references == 3
 
-def test_error_empty_z_matrix():
+        # Orientation and origin are assigned the last degree if present.
+        last_degree = torch.max(degree)
+        assert torch.all(degree[maf_dof_indices['reference']] == last_degree)
+        if n_references > 0:
+            assert torch.count_nonzero(degree == last_degree) == n_references
+
+
+def test_mixed_maf_flow_error_empty_z_matrix():
     """An error is raised if there are no internal coordinates to map."""
     tfep_map = MyMixedMAFMap(batch_size=2, mapped_atoms='resname WAT1')
     with pytest.raises(ValueError, match='no internal coordinates to map'):
         tfep_map.setup()
 
 
-def test_error_no_element_info():
+def test_mixed_maf_flow_error_no_element_info():
     """An error is raised if the topology has no information on atom elements."""
     # Class that removes info on atom elements.
     class _MyMixedMAFMap(MyMixedMAFMap):
@@ -550,26 +924,34 @@ def test_error_no_element_info():
         tfep_map.setup()
 
 
-def test_error_auto_reference_with_origin_or_axes():
+def test_mixed_maf_flow_axes_without_origin():
     """An error is raised if auto_reference_frame is set and origin/axes atoms are given."""
-    with pytest.raises(ValueError, match="origin_atom and axes_atoms must be None"):
+    with pytest.raises(ValueError, match="axes_atoms cannot be passed"):
         MyMixedMAFMap(
             batch_size=2,
             mapped_atoms='resname CLMET',
-            origin_atom=1,
+            origin_atom=None,
             axes_atoms=[3, 6],
-            auto_reference_frame=True
         )
 
 
-def test_error_collinear_atoms():
+def test_mixed_maf_flow_error_collinear_atoms():
     """An error is raised if the Z-matrix results in collinear atoms."""
     tfep_map = MyMixedMAFMap(
         batch_size=2,
-        mapped_atoms='resname BEN and element C and not name C1',
-        conditioning_atoms='resname BEN and name C1',
+        mapped_atoms='resname BEN and element C',
         origin_atom='resname BEN and name C1',
         axes_atoms='resname BEN and (name C or name C4)',
     )
     with pytest.raises(RuntimeError, match='collinear'):
+        tfep_map.setup()
+
+
+def test_mixed_maf_flow_error_fixed_ref_atoms():
+    """An error is raised if the reference frame atoms are fixed."""
+    tfep_map = MyMixedMAFMap(
+        mapped_atoms='resname BEN and element C',
+        origin_atom='resname CLMET and name C1',
+    )
+    with pytest.raises(ValueError, match='atoms must be mapped or conditioning'):
         tfep_map.setup()

--- a/tfep/tests/nn/embeddings/test_mafembed.py
+++ b/tfep/tests/nn/embeddings/test_mafembed.py
@@ -118,6 +118,12 @@ def test_periodic_embedding(n_periodic, limits):
     assert torch.allclose(x_out[0, periodic_indices[1]+1:periodic_indices[1]+3], expected)
 
 
+def test_periodic_embedding_error_repeated_indices():
+    """An error is raised if repeated indices are given."""
+    with pytest.raises(ValueError, match='Found duplicated indices'):
+        PeriodicEmbedding(n_features_in=5, limits=[0, 1], periodic_indices=[0, 1, 1])
+
+
 # =============================================================================
 # TEST FLIP-INVARIANT EMBEDDING
 # =============================================================================
@@ -203,6 +209,13 @@ def test_flip_invariant_embedding_invariance(
 
     # The non-embedded features have flipped.
     assert torch.all(out[:, nonembedded_mask] == -out_flipped[:, nonembedded_mask])
+
+
+def test_flip_invariant_embedding_error_repeated_indices():
+    """An error is raised if repeated indices are given."""
+    with pytest.raises(ValueError, match='Found duplicated indices'):
+        FlipInvariantEmbedding(n_features_in=5, embedding_dimension=3,
+                               embedded_indices=[3, 3, 4])
 
 
 def test_flip_invariant_embedding_error_degrees_in():

--- a/tfep/tests/nn/embeddings/test_mafembed.py
+++ b/tfep/tests/nn/embeddings/test_mafembed.py
@@ -192,7 +192,7 @@ def test_flip_invariant_embedding_invariance(
     out_flipped = embedding(-x)
 
     # Find the output indices through get_degrees_out rather than private variables.
-    degrees_in = torch.zeros(n_features_in)
+    degrees_in = torch.zeros(n_features_in, dtype=int)
     degrees_in[embedded_indices_in] = 1
     degrees_out = embedding.get_degrees_out(degrees_in)
     embedded_mask = degrees_out == 1

--- a/tfep/tests/nn/flows/test_maf.py
+++ b/tfep/tests/nn/flows/test_maf.py
@@ -14,7 +14,6 @@ Test MAF layer in tfep.nn.flows.maf.
 # GLOBAL IMPORTS
 # =============================================================================
 
-import numpy as np
 import pytest
 import torch
 
@@ -24,7 +23,11 @@ from tfep.nn.transformers import (
     MixedTransformer,
 )
 from tfep.nn.conditioners.made import generate_degrees
-from tfep.nn.embeddings.mafembed import PeriodicEmbedding
+from tfep.nn.embeddings.mafembed import (
+    PeriodicEmbedding,
+    FlipInvariantEmbedding,
+    MixedEmbedding,
+)
 from tfep.nn.flows.maf import MAF
 from tfep.utils.misc import remove_and_shift_sorted_indices
 
@@ -52,51 +55,124 @@ def teardown_module(module):
 # UTILITY FUNCTIONS
 # =============================================================================
 
-def create_input(batch_size, dimension_in, limits=None, periodic_indices=None, seed=0):
-    """Create random input with correct boundaries.
+def generate_test_case(
+        conditioning_indices,
+        periodic_indices,
+        flip_invariant_indices,
+        transformer,
+        degrees_in_order,
+        weight_norm,
+        hidden_layers,
+        initialize_identity,
+):
+    """Create a new test case."""
+    batch_size = 2
+    limits = torch.tensor([-1., 1.])
+    embed_dim = 1
+    vector_dim = 2
 
-    If limits=(x0, xf) are passed, the input is constrained to be within x0 and
-    xf. x0 and xf can be both floats or Tensors of size (n_features,).
+    # We increase the number of features by the number of conditioning indices
+    # to make sure that the MoebiusTransformer receives a number divisible by
+    # its vector dimension=2.
+    n_conditioning_indices = 0 if conditioning_indices is None else len(conditioning_indices)
+    n_features = 6 + n_conditioning_indices
 
-    If periodic_indices is passed, only these DOFs are restrained between x0
-    and xf.
+    # Create embedding.
+    if (periodic_indices is None) and (flip_invariant_indices is None):
+        embedding = None
+    elif (periodic_indices is not None) and (flip_invariant_indices is not None):
+        embedding = MixedEmbedding(
+            n_features_in=n_features,
+            embedding_layers=[
+                PeriodicEmbedding(
+                    n_features_in=len(periodic_indices),
+                    limits=limits,
+                ),
+                FlipInvariantEmbedding(
+                    n_features_in=len(flip_invariant_indices),
+                    embedding_dimension=embed_dim,
+                    vector_dimension=vector_dim,
+                )
+            ],
+            embedded_indices=[periodic_indices, flip_invariant_indices]
+        )
+    elif periodic_indices is not None:
+        embedding = PeriodicEmbedding(
+            n_features_in=n_features,
+            periodic_indices=periodic_indices,
+            limits=limits,
+        )
+    else:
+        embedding = FlipInvariantEmbedding(
+            n_features_in=n_features,
+            embedding_dimension=embed_dim,
+            embedded_indices=flip_invariant_indices,
+            vector_dimension=vector_dim,
+        )
 
-    """
-    # The non-periodic features do not need to be restrained between 0 and 1.
-    x = create_random_input(batch_size, dimension_in, x_func=torch.randn, seed=seed)
+    # Generate input degrees.
+    if isinstance(transformer, MoebiusTransformer):
+        repeats = transformer.dimension
+    elif flip_invariant_indices is not None:
+        repeats = torch.ones(n_features, dtype=int)
+        repeats[flip_invariant_indices] = 2
 
-    if (limits is not None) and (periodic_indices is not None):
-        x_periodic = create_random_input(batch_size, len(periodic_indices), x_func=torch.rand, seed=seed)
+        # Repeats does not have conditioning indices and must have only 1
+        # entry for each flip-invariant vector.
+        removed_indices = torch.tensor(flip_invariant_indices[1::vector_dim])
+        if conditioning_indices is not None:
+            removed_indices = torch.cat([torch.tensor(conditioning_indices), removed_indices]).sort().values
+        repeats = repeats[remove_and_shift_sorted_indices(torch.arange(n_features), removed_indices, shift=False)]
+    else:
+        repeats = 1
+    degrees_in = generate_degrees(
+        n_features=n_features,
+        order=degrees_in_order,
+        conditioning_indices=conditioning_indices,
+        repeats=repeats,
+    )
+
+    # Create MAF.
+    maf = MAF(
+        degrees_in=degrees_in,
+        transformer=transformer,
+        hidden_layers=hidden_layers,
+        embedding=embedding,
+        weight_norm=weight_norm,
+        initialize_identity=initialize_identity,
+    )
+
+    # Create random input. We set the limit of periodic indices so that the
+    # MoebiusTransformer cannot move things outside them.
+    x = create_random_input(batch_size, n_features, x_func=torch.randn, seed=0)
+    if periodic_indices is not None:
+        limits = limits / torch.linalg.norm(torch.ones(vector_dim))
+        x_periodic = create_random_input(batch_size, len(periodic_indices), x_func=torch.rand, seed=0)
         x_periodic = x_periodic * (limits[1] - limits[0]) + limits[0]
         x = x.clone()
         x[:, periodic_indices] = x_periodic
 
-    return x
+    return x, maf, degrees_in
 
 
 # =============================================================================
 # TESTS
 # =============================================================================
 
-@pytest.mark.parametrize('hidden_layers', [1, 4])
-@pytest.mark.parametrize('conditioning_indices', [
-    [],
-    [0, 1],
-    [0, 3],
-    [1, 3],
-    [0, 4],
-    [2, 4],
-    [3, 4]
+@pytest.mark.parametrize('conditioning_indices,periodic_indices,flip_invariant_indices', [
+    (None, None, None),
+    ([0, 1], None, None),
+    ([2, 7], None, None),
+    (None, [2], None),
+    (None, [0, 5], None),
+    (None, None, [2, 3]),
+    (None, None, [0, 1, 4, 5]),
+    ([1], [0], [3, 4]),
+    ([4], [2, 3], [0, 1, 5, 6]),
+    ([0, 7], [3], [5, 6]),
+    ([2, 4], [4], [6, 7]),
+    ([0, 3, 4], [6], [3, 4]),
 ])
-@pytest.mark.parametrize('periodic_indices', [
-    None,
-    [0],
-    [1],
-    [1, 2],
-    [0, 2],
-])
-@pytest.mark.parametrize('degrees_in_order', ['ascending', 'descending'])
-@pytest.mark.parametrize('weight_norm', [False, True])
 @pytest.mark.parametrize('transformer', [
     AffineTransformer(),
     SOSPolynomialTransformer(2),
@@ -106,170 +182,107 @@ def create_input(batch_size, dimension_in, limits=None, periodic_indices=None, s
         xf=torch.tensor(1., dtype=torch.double),
         n_bins=3
     ),
-    MoebiusTransformer(dimension=3),
+    MoebiusTransformer(dimension=2),
     MixedTransformer(
         transformers=[AffineTransformer(), SOSPolynomialTransformer(3)],
-        indices=[[0, 2], [1, 3, 4]],
+        indices=[[0, 2, 5], [1, 3, 4]],
     ),
 ])
-def test_identity_initialization_MAF(hidden_layers, conditioning_indices, periodic_indices,
-                                     degrees_in_order, weight_norm, transformer):
+@pytest.mark.parametrize('degrees_in_order', ['ascending', 'descending'])
+@pytest.mark.parametrize('weight_norm', [False, True])
+@pytest.mark.parametrize('hidden_layers', [1, 4])
+def test_maf_identity_initialization(
+        conditioning_indices,
+        periodic_indices,
+        flip_invariant_indices,
+        transformer,
+        degrees_in_order,
+        weight_norm,
+        hidden_layers,
+):
     """Test that the identity initialization of MAF works.
 
     This tests that the flow layers can be initialized to perform the
     identity function.
 
     """
-    n_features = 5
-    batch_size = 2
-    limits = [-1., 1.]
-
-    # Periodic indices with MoebiusTransformer doesn't make sense.
-    if periodic_indices is None:
-        embedding = None
-    else:
-        embedding = PeriodicEmbedding(
-            n_features_in=n_features,
-            periodic_indices=periodic_indices,
-            limits=limits,
-        )
-
-    # With the MoebiusTransformer, the output must be vectors of the same size.
-    if isinstance(transformer, MoebiusTransformer):
-        extra_dim = transformer.dimension - (n_features - len(conditioning_indices)) % transformer.dimension
-        n_features = n_features + extra_dim
-        repeats = transformer.dimension
-    else:
-        repeats = 1
-
-    # Remove the conditioning indices from the MixedTransformer.
-    if isinstance(transformer, MixedTransformer) and len(conditioning_indices) > 0:
-        indices = [remove_and_shift_sorted_indices(idx, torch.tensor(conditioning_indices))
-                   for idx in transformer._indices]
-        transformer = MixedTransformer(transformer._transformers, indices)
-
-    # Create MAF.
-    maf = MAF(
-        degrees_in=generate_degrees(
-            n_features=n_features,
-            order=degrees_in_order,
-            conditioning_indices=conditioning_indices,
-            repeats=repeats,
-        ),
+    x, maf, degrees_in = generate_test_case(
+        conditioning_indices=conditioning_indices,
+        periodic_indices=periodic_indices,
+        flip_invariant_indices=flip_invariant_indices,
         transformer=transformer,
-        hidden_layers=hidden_layers,
-        embedding=embedding,
+        degrees_in_order=degrees_in_order,
         weight_norm=weight_norm,
+        hidden_layers=hidden_layers,
         initialize_identity=True,
     )
 
-    # Create random input and forward.
-    x = create_input(batch_size, n_features, limits=limits,
-                     periodic_indices=periodic_indices)
+    # Test identity.
     y, log_det_J = maf.forward(x)
     assert torch.allclose(x, y)
-    assert torch.allclose(log_det_J, torch.zeros(batch_size), atol=1e-6)
+    assert torch.allclose(log_det_J, torch.zeros_like(log_det_J), atol=1e-6)
 
 
-@pytest.mark.parametrize('conditioning_indices', [
-    [],
-    [0, 1],
-    [0, 3],
-    [1, 3],
-    [0, 4],
-    [2, 4],
-    [3, 4]
-])
-@pytest.mark.parametrize('periodic_indices', [
-    None,
-    [0],
-    [1],
-    [1, 2],
-    [0, 2],
+@pytest.mark.parametrize('conditioning_indices,periodic_indices,flip_invariant_indices', [
+    (None, None, None),
+    ([0, 1], None, None),
+    ([2, 7], None, None),
+    (None, [2], None),
+    (None, [0, 5], None),
+    (None, None, [2, 3]),
+    (None, None, [0, 1, 4, 5]),
+    ([1], [0], [3, 4]),
+    ([4], [2, 3], [0, 1, 5, 6]),
+    ([0, 7], [3], [5, 6]),
+    ([2, 4], [4], [6, 7]),
+    ([0, 3, 4], [6], [3, 4]),
 ])
 @pytest.mark.parametrize('degrees_in_order', ['ascending', 'descending', 'random'])
 @pytest.mark.parametrize('transformer', [
     AffineTransformer(),
-    MoebiusTransformer(dimension=3),
+    MoebiusTransformer(dimension=2),
     MixedTransformer(
         transformers=[
             AffineTransformer(),
             NeuralSplineTransformer(
-                x0=torch.tensor(0., dtype=torch.double),
-                xf=torch.tensor(2., dtype=torch.double),
+                x0=torch.tensor(-1., dtype=torch.double),
+                xf=torch.tensor(1., dtype=torch.double),
                 n_bins=3,
             ),
         ],
-        indices=[[2, 0, 3], [4, 1]],
+        indices=[[1, 4], [0, 2, 3, 5]],
     )
 ])
 @pytest.mark.parametrize('weight_norm', [False, True])
-def test_maf_autoregressive_round_trip(conditioning_indices, periodic_indices, degrees_in_order, weight_norm, transformer):
+def test_maf_autoregressive_round_trip(
+        conditioning_indices,
+        periodic_indices,
+        flip_invariant_indices,
+        degrees_in_order,
+        weight_norm,
+        transformer,
+):
     """Test the autoregressive property and that the MAF.inverse(MAF.forward(x)) equals the identity."""
-    n_features = 5
-    batch_size = 2
-    limits = (0., 2.)
-
-    # Periodic indices with MoebiusTransformer doens't make sense.
-    if periodic_indices is None:
-        embedding = None
-    elif isinstance(transformer, MoebiusTransformer):
-        pytest.skip('Vector inputs for Moebius transformers are not compatible with periodic.')
-    else:
-        embedding = PeriodicEmbedding(
-            n_features_in=n_features,
-            periodic_indices=periodic_indices,
-            limits=limits,
-        )
-
-    # With the MoebiusTransformer, the output must be vectors of the same size.
-    if isinstance(transformer, MoebiusTransformer):
-        extra_dim = transformer.dimension - (n_features - len(conditioning_indices)) % transformer.dimension
-        n_features = n_features + extra_dim
-        repeats = transformer.dimension
-    else:
-        repeats = 1
-
-    # Remove the conditioning indices from the MixedTransformer.
-    if isinstance(transformer, MixedTransformer) and len(conditioning_indices) > 0:
-        indices = [remove_and_shift_sorted_indices(idx, torch.tensor(conditioning_indices))
-                   for idx in transformer._indices]
-        transformer = MixedTransformer(transformer._transformers, indices)
-
-    # Input degrees.
-    degrees_in = generate_degrees(
-        n_features=n_features,
-        order=degrees_in_order,
+    x, maf, degrees_in = generate_test_case(
         conditioning_indices=conditioning_indices,
-        repeats=repeats,
-    )
-
-    # We don't initialize as the identity function to make the test meaningful.
-    maf = MAF(
-        degrees_in=degrees_in,
-        transformer=transformer,
-        hidden_layers=2,
-        embedding=embedding,
-        weight_norm=weight_norm,
-        initialize_identity=False,
-    )
-
-    # Create random input.
-    x = create_input(
-        batch_size,
-        n_features,
-        limits=limits,
         periodic_indices=periodic_indices,
+        flip_invariant_indices=flip_invariant_indices,
+        transformer=transformer,
+        degrees_in_order=degrees_in_order,
+        weight_norm=weight_norm,
+        hidden_layers=2,
+        initialize_identity=False,
     )
 
     # The conditioning features are always left unchanged.
     y, log_det_J = maf.forward(x)
-    assert torch.allclose(x[:, conditioning_indices], y[:, conditioning_indices])
+    if conditioning_indices is not None:
+        assert torch.allclose(x[:, conditioning_indices], y[:, conditioning_indices])
 
     # Inverting the transformation produces the input vector.
     x_inv, log_det_J_inv = maf.inverse(y)
     assert torch.allclose(x, x_inv)
-    assert torch.allclose(log_det_J + log_det_J_inv, torch.zeros(batch_size), atol=1e-04)
+    assert torch.allclose(log_det_J + log_det_J_inv, torch.zeros_like(log_det_J), atol=1e-04)
 
     # Test the autoregressive property.
     check_autoregressive_property(

--- a/tfep/tests/nn/transformers/test_moebius.py
+++ b/tfep/tests/nn/transformers/test_moebius.py
@@ -167,10 +167,10 @@ def reference_symmetrized_moebius_transformer(x, w, dimension):
     (4, 4),
     (8, 4),
 ])
-@pytest.mark.parametrize('unit_sphere', [True, False])
-@pytest.mark.parametrize('transformer_cls', [
-    MoebiusTransformer,
-    SymmetrizedMoebiusTransformer
+@pytest.mark.parametrize('unit_sphere,transformer_cls', [
+    (True, MoebiusTransformer),
+    (False, MoebiusTransformer),
+    (None, SymmetrizedMoebiusTransformer),
 ])
 def test_moebius_transformer_reference(batch_size, n_features, dimension, unit_sphere, transformer_cls):
     """Compare PyTorch and reference implementation of MoebiusTransformer."""
@@ -244,10 +244,10 @@ def test_moebius_transformer_identity(batch_size, n_features, dimension, unit_sp
     (4, 4),
     (8, 4),
 ])
-@pytest.mark.parametrize('unit_sphere', [True, False])
-@pytest.mark.parametrize('transformer_cls', [
-    MoebiusTransformer,
-    SymmetrizedMoebiusTransformer
+@pytest.mark.parametrize('unit_sphere,transformer_cls', [
+    (True, MoebiusTransformer),
+    (False, MoebiusTransformer),
+    (None, SymmetrizedMoebiusTransformer),
 ])
 def test_moebius_transformer_inverse(batch_size, n_features, dimension, unit_sphere, transformer_cls):
     """Compare PyTorch and reference implementation of MoebiusTransformer."""

--- a/tfep/tests/nn/transformers/test_moebius.py
+++ b/tfep/tests/nn/transformers/test_moebius.py
@@ -207,17 +207,14 @@ def test_moebius_transformer_reference(batch_size, n_features, dimension, unit_s
     (4, 4),
     (8, 4),
 ])
-@pytest.mark.parametrize('unit_sphere', [True, False])
-@pytest.mark.parametrize('transformer_cls', [
-    MoebiusTransformer,
-    SymmetrizedMoebiusTransformer
+@pytest.mark.parametrize('unit_sphere,transformer_cls', [
+    (True, MoebiusTransformer),
+    (False, MoebiusTransformer),
+    (None, SymmetrizedMoebiusTransformer),
 ])
 def test_moebius_transformer_identity(batch_size, n_features, dimension, unit_sphere, transformer_cls):
     """The MoebiusTransform can implement the identity function correctly."""
     x, _ = create_moebius_random_input(batch_size, n_features, dimension, unit_sphere)
-
-    # The identity should be encoded with parameters w = 0.
-    w = torch.zeros_like(x)
 
     # Compare PyTorch and reference.
     if transformer_cls == MoebiusTransformer:
@@ -225,7 +222,15 @@ def test_moebius_transformer_identity(batch_size, n_features, dimension, unit_sp
     else:
         transformer = transformer_cls(dimension=dimension)
 
+    # The identity should be encoded with parameters w = 0.
+    w = transformer.get_identity_parameters(x.shape[1]).expand(batch_size, -1)
+
     y, log_det_J = transformer(x, w)
+    assert torch.allclose(x, y)
+    assert torch.allclose(log_det_J, torch.zeros_like(log_det_J))
+
+    # Test also inverse.
+    y, log_det_J = transformer.inverse(x, w)
     assert torch.allclose(x, y)
     assert torch.allclose(log_det_J, torch.zeros_like(log_det_J))
 

--- a/tfep/tests/nn/transformers/test_quatprod.py
+++ b/tfep/tests/nn/transformers/test_quatprod.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test objects and function in tfep.nn.transformers.moebius.
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import pytest
+import torch
+
+from tfep.nn.transformers.quatprod import QuaternionProductTransformer
+
+
+# =============================================================================
+# TEST MODULE CONFIGURATION
+# =============================================================================
+
+_old_default_dtype = None
+
+def setup_module(module):
+    global _old_default_dtype
+    _old_default_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.double)
+
+
+def teardown_module(module):
+    torch.set_default_dtype(_old_default_dtype)
+
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+@pytest.mark.parametrize('batch_size', [1, 3])
+@pytest.mark.parametrize('n_quaternions', [1, 3])
+def test_quat_product_transformer_identity(batch_size, n_quaternions):
+    """QuaternionProductTransformer.get_identity_parameters returns the parameters for the identity."""
+    # roma is an optional dependency at the moment
+    roma = pytest.importorskip('roma')
+
+    transformer = QuaternionProductTransformer()
+    w = transformer.get_identity_parameters(n_quaternions*4).expand(batch_size, -1)
+    q = roma.random_unitquat(batch_size*n_quaternions).reshape(batch_size, -1)
+    q2, log_det_J = transformer(q, w)
+    assert torch.allclose(q, q2)
+    assert torch.allclose(log_det_J, torch.zeros_like(log_det_J))
+
+
+@pytest.mark.parametrize('batch_size', [1, 3])
+@pytest.mark.parametrize('n_quaternions', [1, 3])
+def test_quat_product_transformer_round_trip(batch_size, n_quaternions):
+    """Check that a forward-inverse round-trip with QuaternionProductTransformer is the identity."""
+    # roma is an optional dependency at the moment
+    roma = pytest.importorskip('roma')
+
+    transformer = QuaternionProductTransformer()
+    w = torch.randn(batch_size, n_quaternions*4)
+    q = roma.random_unitquat(batch_size*n_quaternions).reshape(batch_size, -1).to(w)
+    q2, log_det_J = transformer(q, w)
+    q_inv, log_det_J_inv = transformer.inverse(q2, w)
+
+    assert torch.allclose(q, q_inv)
+    assert torch.allclose(log_det_J, torch.zeros_like(log_det_J))
+    assert torch.allclose(log_det_J, log_det_J_inv)
+
+
+@pytest.mark.parametrize('batch_size', [1, 3])
+@pytest.mark.parametrize('n_quaternions', [1, 3])
+def test_quat_product_transformer_flip_equivariance(batch_size, n_quaternions):
+    """The QuaternionProductTransformer is flip equivariant w.r.t. its input."""
+    # roma is an optional dependency at the moment
+    roma = pytest.importorskip('roma')
+
+    transformer = QuaternionProductTransformer()
+    w = torch.randn(batch_size, n_quaternions*4)
+    q = roma.random_unitquat(batch_size*n_quaternions).reshape(batch_size, -1).to(w)
+
+    # Compare the transformation with the input and its negative.
+    q2, log_det_J = transformer(q, w)
+    q2_neg, log_det_J_neg = transformer(-q, w)
+    assert torch.allclose(q2, -q2_neg)

--- a/tfep/tests/utils/test_misc.py
+++ b/tfep/tests/utils/test_misc.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 import torch
 
-from tfep.utils.misc import ensure_tensor_sequence
+from tfep.utils.misc import ensure_tensor_sequence, remove_and_shift_sorted_indices
 
 
 # =============================================================================
@@ -44,3 +44,58 @@ def test_ensure_int_tensor_sequence(x, expected):
     except TypeError:
         assert y == expected
         assert type(y) == type(expected)
+
+
+@pytest.mark.parametrize('indices,removed_indices,remove,shift,expected', [
+    (
+        [0, 2, 3, 7],
+        [1, 3, 5],
+        True, True,
+        [0, 1, 4],
+    ), (
+        [0, 2, 3, 7],
+        [1, 3, 5],
+        True, False,
+        [0, 2, 7],
+    ), (
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        True, True,
+        [],
+    ), (
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        True, False,
+        [],
+    ), (
+        [3, 5, 8, 12, 15],
+        [2, 7],
+        True, True,
+        [2, 4, 6, 10, 13],
+    ), (
+        [3, 5, 8, 12, 15],
+        [2, 7],
+        True, False,
+        [3, 5, 8, 12, 15],
+    ), (
+        [3, 5, 8, 12, 15],
+        [2, 7],
+        False, True,
+        [2, 4, 6, 10, 13],
+    )
+])
+def test_remove_and_shift_sorted_indices(
+        indices,
+        removed_indices,
+        remove,
+        shift,
+        expected,
+):
+    """Test utility method remove_and_shift_sorted_indices()."""
+    out = remove_and_shift_sorted_indices(
+        indices=torch.tensor(indices),
+        removed_indices=torch.tensor(removed_indices),
+        remove=remove,
+        shift=shift,
+    )
+    assert torch.all(torch.tensor(expected) == out)

--- a/tfep/utils/geometry.py
+++ b/tfep/utils/geometry.py
@@ -362,11 +362,16 @@ def reference_frame_rotation_matrix(
     """
     # Default argument.
     if plane_normal is None:
-        plane_normal = torch.cross(axis, plane_axis)
+        plane_normal = torch.cross(axis, plane_axis, dim=0)
 
     # Find the direction perpendicular to the plane formed by the axis atom,
     # and the axis. rotation_vectors has shape (batch_size, 3).
     rotation_vectors = torch.cross(axis_atom_positions, axis.unsqueeze(0), dim=1)
+
+    # If axis_atom_positions lies exactly on axis, any perpendicular vector
+    # will do. Shape (batch_size,).
+    is_parallel = torch.isclose(rotation_vectors, torch.zeros(1)).all(dim=1)
+    rotation_vectors[is_parallel] = torch.cross(plane_axis, axis, dim=0)
 
     # Find the first rotation angle. r1_angle has shape (batch_size,).
     r1_angles = vector_vector_angle(axis_atom_positions, axis)


### PR DESCRIPTION
**New features**
- Changes to ``MixedMAFMap``
  - Always perform the flow transformation in a relative frame of reference. If ``origin_atom`` and ``axes_atoms`` are not passed, these are automatically determined.
  - Added support to map global rototranslational degrees of freedom while maintaining a relative frame of reference.
- Added new ``FlipInvariantEmbedding`` and ``MixedEmbedding`` layers.
- Added ``QuaternionProductTransformer`` transformer for autoregressive flows.

**Enhancements**
- Simplified identity initialization of ``NeuralSplineTransformer``.

**Bugfixes**
- Fixed bug in determining rotation matrix when the axis and plane atoms are parallel.
